### PR TITLE
feat(cli): Add Repay Command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use stellar_defi_toolkit::{InterestRateModel, LendingProtocol, PriceOracle};
+use stellar_defi_toolkit::{InterestRateModel, LendingProtocol, PriceOracle, ReserveConfig};
 
 #[derive(Parser)]
 #[command(name = "stellar-defi-cli")]
@@ -15,6 +15,19 @@ enum Commands {
     QuoteRate {
         #[arg(long, help = "Utilization in basis points, e.g. 8000 for 80%")]
         utilization_bps: u32,
+    },
+    /// Repay a borrowed asset.
+    Repay {
+        #[arg(long, help = "The account repaying the debt")]
+        payer: String,
+        #[arg(long, help = "The account whose debt is being repaid")]
+        borrower: String,
+        #[arg(long, help = "The asset being repaid")]
+        asset: String,
+        #[arg(long, help = "The amount to repay")]
+        amount: i128,
+        #[arg(long, help = "Current timestamp in seconds")]
+        now: u64,
     },
 }
 
@@ -37,6 +50,66 @@ fn main() {
                 protocol.admin(),
                 oracle.admin()
             );
+        }
+        Commands::Repay {
+            payer,
+            borrower,
+            asset,
+            amount,
+            now,
+        } => {
+            let model = InterestRateModel::default();
+            let mut protocol = LendingProtocol::new("admin", "treasury", model);
+            let mut oracle = PriceOracle::new("oracle-admin");
+
+            // Mocking a state so the repay actually succeeds
+            let config = ReserveConfig {
+                asset: asset.clone(),
+                decimals: 7,
+                collateral_factor_bps: 8000,
+                liquidation_threshold_bps: 8500,
+                liquidation_bonus_bps: 500,
+                reserve_factor_bps: 1000,
+                flash_loan_fee_bps: 9,
+                borrow_enabled: true,
+                deposit_enabled: true,
+                flash_loan_enabled: true,
+            };
+
+            if let Err(e) = protocol.register_asset("admin", config, 0) {
+                println!("Failed to register asset: {:?}", e);
+                return;
+            }
+
+            if let Err(e) = oracle.set_price("oracle-admin", &asset, 1_000_000_000) {
+                println!("Failed to set oracle price: {:?}", e);
+                return;
+            }
+
+            // Seed the reserve with a deposit from some liquidity provider
+            let initial_deposit = amount * 10;
+            if let Err(e) = protocol.deposit("liquidity_provider", &asset, initial_deposit, 0) {
+                println!("Failed initial deposit: {:?}", e);
+                return;
+            }
+
+            // The borrower borrows an amount
+            let borrow_amount = amount;
+            // The borrower needs collateral first to borrow
+            if let Err(e) = protocol.deposit(&borrower, &asset, borrow_amount * 2, 0) {
+                println!("Failed borrower deposit: {:?}", e);
+                return;
+            }
+            if let Err(e) = protocol.borrow(&borrower, &asset, borrow_amount, &oracle, 0) {
+                println!("Failed to borrow: {:?}", e);
+                return;
+            }
+
+            // Finally perform the repay operation requested by the user
+            match protocol.repay(&payer, &borrower, &asset, amount, now) {
+                Ok(repaid) => println!("Successfully repaid {} of asset {}", repaid, asset),
+                Err(e) => println!("Failed to repay: {:?}", e),
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Adds the `Repay` subcommand to the CLI to facilitate repayment of borrowed assets within the Soroban lending protocol playground.

### Changes
*   Added `Repay` variant to `Commands` in `src/main.rs` via `clap`.
*   Includes arguments for `--payer`, `--borrower`, `--asset`, `--amount`, and `--now`.
*   Simulated a complete protocol state lifecycle (Asset Registration -> Mock Oracle Price -> Supplier Deposit -> Borrower Deposit -> Borrow) prior to executing `protocol.repay()` so the command correctly demonstrates a successful repayment in the stateless playground instead of returning an immediate error.

Closes #62
