### PR TITLE
feat(lending): per-asset interest rate models, supply caps, borrow caps, and dynamic reserve factors

### DIFF
--- a/src/contracts/lending.rs
+++ b/src/contracts/lending.rs
@@ -12,7 +12,9 @@ use crate::utils::{bps_mul, mul_div, wad_div, WAD, YEAR_IN_SECONDS};
 pub struct LendingProtocol {
     admin: String,
     treasury: String,
-    interest_rate_model: InterestRateModel,
+    /// Protocol-level default interest rate model, used when a reserve has no
+    /// per-asset model configured.
+    default_interest_rate_model: InterestRateModel,
     reserves: BTreeMap<String, ReserveState>,
     reserve_configs: BTreeMap<String, ReserveConfig>,
     accounts: BTreeMap<String, AccountPosition>,
@@ -28,7 +30,7 @@ impl LendingProtocol {
         Self {
             admin: admin.into(),
             treasury: treasury.into(),
-            interest_rate_model,
+            default_interest_rate_model: interest_rate_model,
             reserves: BTreeMap::new(),
             reserve_configs: BTreeMap::new(),
             accounts: BTreeMap::new(),
@@ -44,6 +46,19 @@ impl LendingProtocol {
         &self.treasury
     }
 
+    /// Returns the protocol-level default interest rate model.
+    pub fn default_interest_rate_model(&self) -> &InterestRateModel {
+        &self.default_interest_rate_model
+    }
+
+    /// Returns the effective interest rate model for `asset`: the per-asset
+    /// model when one is configured, otherwise the protocol default.
+    pub fn interest_rate_model_for(&self, asset: &str) -> Option<&InterestRateModel> {
+        self.reserve_configs
+            .get(asset)
+            .map(|cfg| cfg.interest_rate_model.as_ref().unwrap_or(&self.default_interest_rate_model))
+    }
+
     pub fn set_close_factor(
         &mut self,
         caller: &str,
@@ -51,6 +66,90 @@ impl LendingProtocol {
     ) -> Result<(), ProtocolError> {
         self.ensure_admin(caller)?;
         self.close_factor_bps = close_factor_bps;
+        Ok(())
+    }
+
+    /// Replace the protocol-level default interest rate model.
+    pub fn set_default_interest_rate_model(
+        &mut self,
+        caller: &str,
+        model: InterestRateModel,
+    ) -> Result<(), ProtocolError> {
+        self.ensure_admin(caller)?;
+        self.default_interest_rate_model = model;
+        Ok(())
+    }
+
+    /// Set (or clear) the per-asset interest rate model for `asset`.
+    ///
+    /// Pass `Some(model)` to override the protocol default for this asset, or
+    /// `None` to revert to the protocol default.
+    pub fn set_asset_interest_rate_model(
+        &mut self,
+        caller: &str,
+        asset: &str,
+        model: Option<InterestRateModel>,
+    ) -> Result<(), ProtocolError> {
+        self.ensure_admin(caller)?;
+        let config = self
+            .reserve_configs
+            .get_mut(asset)
+            .ok_or(ProtocolError::UnknownAsset)?;
+        config.interest_rate_model = model;
+        Ok(())
+    }
+
+    /// Update the supply cap for `asset`.  A value of `0` removes the cap.
+    pub fn set_supply_cap(
+        &mut self,
+        caller: &str,
+        asset: &str,
+        supply_cap: i128,
+    ) -> Result<(), ProtocolError> {
+        self.ensure_admin(caller)?;
+        let config = self
+            .reserve_configs
+            .get_mut(asset)
+            .ok_or(ProtocolError::UnknownAsset)?;
+        config.supply_cap = supply_cap;
+        Ok(())
+    }
+
+    /// Update the borrow cap for `asset`.  A value of `0` removes the cap.
+    pub fn set_borrow_cap(
+        &mut self,
+        caller: &str,
+        asset: &str,
+        borrow_cap: i128,
+    ) -> Result<(), ProtocolError> {
+        self.ensure_admin(caller)?;
+        let config = self
+            .reserve_configs
+            .get_mut(asset)
+            .ok_or(ProtocolError::UnknownAsset)?;
+        config.borrow_cap = borrow_cap;
+        Ok(())
+    }
+
+    /// Update the reserve factor for `asset` in basis points (0–10 000).
+    ///
+    /// The reserve factor controls what fraction of accrued interest is
+    /// redirected to the protocol treasury.
+    pub fn set_reserve_factor(
+        &mut self,
+        caller: &str,
+        asset: &str,
+        reserve_factor_bps: u32,
+    ) -> Result<(), ProtocolError> {
+        self.ensure_admin(caller)?;
+        if reserve_factor_bps > 10_000 {
+            return Err(ProtocolError::InvalidReserveFactor);
+        }
+        let config = self
+            .reserve_configs
+            .get_mut(asset)
+            .ok_or(ProtocolError::UnknownAsset)?;
+        config.reserve_factor_bps = reserve_factor_bps;
         Ok(())
     }
 
@@ -114,7 +213,15 @@ impl LendingProtocol {
         } else {
             wad_div(state.total_debt, supplied).map_err(|_| ProtocolError::MathFailure)?
         };
-        let borrow_rate = self.interest_rate_model.borrow_rate(utilization);
+
+        // Use the per-asset model when configured, otherwise fall back to the
+        // protocol-level default.
+        let model = config
+            .interest_rate_model
+            .as_ref()
+            .unwrap_or(&self.default_interest_rate_model);
+        let borrow_rate = model.borrow_rate(utilization);
+
         let accrued = mul_div(
             state.total_debt,
             borrow_rate
@@ -156,6 +263,18 @@ impl LendingProtocol {
             .ok_or(ProtocolError::UnknownAsset)?;
         if !config.deposit_enabled {
             return Err(ProtocolError::DepositsDisabled(asset.to_string()));
+        }
+
+        // Enforce supply cap (0 means uncapped).
+        let reserve = self
+            .reserves
+            .get(asset)
+            .ok_or(ProtocolError::UnknownAsset)?;
+        if config.supply_cap > 0 {
+            let total_supplied = reserve.total_cash + reserve.total_debt - reserve.protocol_fees;
+            if total_supplied + amount > config.supply_cap {
+                return Err(ProtocolError::SupplyCapExceeded(asset.to_string()));
+            }
         }
 
         let reserve = self
@@ -305,6 +424,11 @@ impl LendingProtocol {
                 .ok_or(ProtocolError::UnknownAsset)?;
             if reserve.total_cash < amount {
                 return Err(ProtocolError::InsufficientLiquidity);
+            }
+
+            // Enforce borrow cap (0 means uncapped).
+            if config.borrow_cap > 0 && reserve.total_debt + amount > config.borrow_cap {
+                return Err(ProtocolError::BorrowCapExceeded(asset.to_string()));
             }
         }
 

--- a/src/types/lending.rs
+++ b/src/types/lending.rs
@@ -34,6 +34,12 @@ pub struct ReserveConfig {
     pub borrow_enabled: bool,
     pub deposit_enabled: bool,
     pub flash_loan_enabled: bool,
+    /// Maximum total amount that can be supplied for this asset (0 = no cap).
+    pub supply_cap: i128,
+    /// Maximum total amount that can be borrowed for this asset (0 = no cap).
+    pub borrow_cap: i128,
+    /// Per-asset interest rate model. When `None` the protocol-level default is used.
+    pub interest_rate_model: Option<InterestRateModel>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -135,6 +141,12 @@ pub enum ProtocolError {
     MathFailure,
     #[error("price unavailable for asset {0}")]
     MissingPrice(String),
+    #[error("supply cap exceeded for asset {0}")]
+    SupplyCapExceeded(String),
+    #[error("borrow cap exceeded for asset {0}")]
+    BorrowCapExceeded(String),
+    #[error("reserve factor must be <= 10000 bps")]
+    InvalidReserveFactor,
 }
 
 impl InterestRateModel {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -14,6 +14,9 @@ fn reserve(asset: &str, collateral_factor_bps: u32) -> ReserveConfig {
         borrow_enabled: true,
         deposit_enabled: true,
         flash_loan_enabled: true,
+        supply_cap: 0,
+        borrow_cap: 0,
+        interest_rate_model: None,
     }
 }
 
@@ -169,4 +172,311 @@ fn disabling_collateral_is_blocked_if_it_would_break_health_factor() {
         .set_collateral_enabled("alice", "XLM", false, &oracle)
         .unwrap_err();
     assert_eq!(err, ProtocolError::HealthFactorTooLow);
+}
+
+// ── Feature: per-asset interest rate models ──────────────────────────────────
+
+#[test]
+fn per_asset_interest_rate_model_overrides_protocol_default() {
+    // Set up a protocol with a very low default rate, then give USDC a much
+    // steeper model and verify that USDC accrues more interest than XLM.
+    let default_model = InterestRateModel {
+        base_rate: 10_000_000,   // 1 %
+        slope_1: 40_000_000,     // 4 %
+        slope_2: 400_000_000,    // 40 %
+        optimal_utilization: 800_000_000,
+    };
+    let steep_model = InterestRateModel {
+        base_rate: 100_000_000,  // 10 %
+        slope_1: 400_000_000,    // 40 %
+        slope_2: 2_000_000_000,  // 200 %
+        optimal_utilization: 800_000_000,
+    };
+
+    let mut protocol = LendingProtocol::new("admin", "treasury", default_model);
+    protocol
+        .register_asset("admin", reserve("XLM", 8_000), 0)
+        .unwrap();
+    protocol
+        .register_asset("admin", reserve("USDC", 9_000), 0)
+        .unwrap();
+
+    // Assign the steep model only to USDC.
+    protocol
+        .set_asset_interest_rate_model("admin", "USDC", Some(steep_model))
+        .unwrap();
+
+    let mut oracle = PriceOracle::new("oracle");
+    oracle.set_price("oracle", "XLM", WAD).unwrap();
+    oracle.set_price("oracle", "USDC", WAD).unwrap();
+
+    // Provide liquidity and create borrows at ~80 % utilization for both assets.
+    protocol.deposit("lp", "XLM", 5_000_000, 0).unwrap();
+    protocol.deposit("lp", "USDC", 5_000_000, 0).unwrap();
+    protocol.deposit("alice", "XLM", 10_000_000, 0).unwrap();
+    protocol
+        .borrow("alice", "XLM", 4_000_000, &oracle, 0)
+        .unwrap();
+    protocol
+        .borrow("alice", "USDC", 4_000_000, &oracle, 0)
+        .unwrap();
+
+    let one_year = 31_536_000_u64;
+    protocol.accrue_interest("XLM", one_year).unwrap();
+    protocol.accrue_interest("USDC", one_year).unwrap();
+
+    let xlm_debt = protocol.reserve_state("XLM").unwrap().total_debt;
+    let usdc_debt = protocol.reserve_state("USDC").unwrap().total_debt;
+
+    // USDC has a steeper model so it must accrue more interest.
+    assert!(
+        usdc_debt > xlm_debt,
+        "USDC debt ({usdc_debt}) should exceed XLM debt ({xlm_debt}) due to steeper model"
+    );
+}
+
+#[test]
+fn clearing_per_asset_model_reverts_to_protocol_default() {
+    let default_model = InterestRateModel::default();
+    let steep_model = InterestRateModel {
+        base_rate: 200_000_000,
+        slope_1: 800_000_000,
+        slope_2: 3_000_000_000,
+        optimal_utilization: 800_000_000,
+    };
+
+    let mut protocol = LendingProtocol::new("admin", "treasury", default_model.clone());
+    protocol
+        .register_asset("admin", reserve("USDC", 9_000), 0)
+        .unwrap();
+
+    protocol
+        .set_asset_interest_rate_model("admin", "USDC", Some(steep_model))
+        .unwrap();
+    // Clear the override — should fall back to default.
+    protocol
+        .set_asset_interest_rate_model("admin", "USDC", None)
+        .unwrap();
+
+    // The effective model should now equal the default.
+    let effective = protocol.interest_rate_model_for("USDC").unwrap();
+    assert_eq!(*effective, default_model);
+}
+
+#[test]
+fn non_admin_cannot_set_asset_interest_rate_model() {
+    let mut protocol = LendingProtocol::new("admin", "treasury", InterestRateModel::default());
+    protocol
+        .register_asset("admin", reserve("USDC", 9_000), 0)
+        .unwrap();
+
+    let err = protocol
+        .set_asset_interest_rate_model("alice", "USDC", Some(InterestRateModel::default()))
+        .unwrap_err();
+    assert_eq!(err, ProtocolError::Unauthorized);
+}
+
+// ── Feature: supply caps ──────────────────────────────────────────────────────
+
+#[test]
+fn deposit_is_rejected_when_supply_cap_is_reached() {
+    let mut protocol = LendingProtocol::new("admin", "treasury", InterestRateModel::default());
+    protocol
+        .register_asset("admin", reserve("USDC", 9_000), 0)
+        .unwrap();
+
+    // Set a tight supply cap of 1 000 000.
+    protocol.set_supply_cap("admin", "USDC", 1_000_000).unwrap();
+
+    // First deposit fits within the cap.
+    protocol.deposit("alice", "USDC", 800_000, 0).unwrap();
+
+    // Second deposit would push total supplied past the cap.
+    let err = protocol.deposit("bob", "USDC", 300_000, 0).unwrap_err();
+    assert_eq!(err, ProtocolError::SupplyCapExceeded("USDC".to_string()));
+}
+
+#[test]
+fn deposit_succeeds_when_supply_cap_is_zero_uncapped() {
+    let mut protocol = LendingProtocol::new("admin", "treasury", InterestRateModel::default());
+    protocol
+        .register_asset("admin", reserve("USDC", 9_000), 0)
+        .unwrap();
+
+    // supply_cap = 0 means no cap.
+    protocol.set_supply_cap("admin", "USDC", 0).unwrap();
+    protocol.deposit("alice", "USDC", 100_000_000, 0).unwrap();
+    let state = protocol.reserve_state("USDC").unwrap();
+    assert_eq!(state.total_cash, 100_000_000);
+}
+
+#[test]
+fn non_admin_cannot_set_supply_cap() {
+    let mut protocol = LendingProtocol::new("admin", "treasury", InterestRateModel::default());
+    protocol
+        .register_asset("admin", reserve("USDC", 9_000), 0)
+        .unwrap();
+
+    let err = protocol
+        .set_supply_cap("alice", "USDC", 1_000_000)
+        .unwrap_err();
+    assert_eq!(err, ProtocolError::Unauthorized);
+}
+
+// ── Feature: borrow caps ──────────────────────────────────────────────────────
+
+#[test]
+fn borrow_is_rejected_when_borrow_cap_is_reached() {
+    let mut protocol = LendingProtocol::new("admin", "treasury", InterestRateModel::default());
+    protocol
+        .register_asset("admin", reserve("XLM", 8_000), 0)
+        .unwrap();
+    protocol
+        .register_asset("admin", reserve("USDC", 9_000), 0)
+        .unwrap();
+
+    let mut oracle = PriceOracle::new("oracle");
+    oracle.set_price("oracle", "XLM", WAD).unwrap();
+    oracle.set_price("oracle", "USDC", WAD).unwrap();
+
+    // Provide ample liquidity.
+    protocol.deposit("lp", "USDC", 10_000_000, 0).unwrap();
+    // Alice deposits XLM as collateral.
+    protocol.deposit("alice", "XLM", 10_000_000, 0).unwrap();
+
+    // Cap USDC borrows at 500 000.
+    protocol.set_borrow_cap("admin", "USDC", 500_000).unwrap();
+
+    // First borrow fits.
+    protocol
+        .borrow("alice", "USDC", 400_000, &oracle, 0)
+        .unwrap();
+
+    // Second borrow would exceed the cap.
+    let err = protocol
+        .borrow("alice", "USDC", 200_000, &oracle, 0)
+        .unwrap_err();
+    assert_eq!(err, ProtocolError::BorrowCapExceeded("USDC".to_string()));
+}
+
+#[test]
+fn borrow_succeeds_when_borrow_cap_is_zero_uncapped() {
+    let mut protocol = LendingProtocol::new("admin", "treasury", InterestRateModel::default());
+    protocol
+        .register_asset("admin", reserve("XLM", 8_000), 0)
+        .unwrap();
+    protocol
+        .register_asset("admin", reserve("USDC", 9_000), 0)
+        .unwrap();
+
+    let mut oracle = PriceOracle::new("oracle");
+    oracle.set_price("oracle", "XLM", WAD).unwrap();
+    oracle.set_price("oracle", "USDC", WAD).unwrap();
+
+    protocol.deposit("lp", "USDC", 5_000_000, 0).unwrap();
+    protocol.deposit("alice", "XLM", 5_000_000, 0).unwrap();
+
+    // borrow_cap = 0 means no cap.
+    protocol.set_borrow_cap("admin", "USDC", 0).unwrap();
+    protocol
+        .borrow("alice", "USDC", 4_000_000, &oracle, 0)
+        .unwrap();
+    let state = protocol.reserve_state("USDC").unwrap();
+    assert_eq!(state.total_debt, 4_000_000);
+}
+
+#[test]
+fn non_admin_cannot_set_borrow_cap() {
+    let mut protocol = LendingProtocol::new("admin", "treasury", InterestRateModel::default());
+    protocol
+        .register_asset("admin", reserve("USDC", 9_000), 0)
+        .unwrap();
+
+    let err = protocol
+        .set_borrow_cap("alice", "USDC", 500_000)
+        .unwrap_err();
+    assert_eq!(err, ProtocolError::Unauthorized);
+}
+
+// ── Feature: dynamic reserve factors ─────────────────────────────────────────
+
+#[test]
+fn reserve_factor_update_changes_protocol_fee_accrual() {
+    let (mut protocol, oracle) = setup_protocol();
+
+    // Provide liquidity and create a borrow.
+    protocol.deposit("lp", "USDC", 5_000_000, 0).unwrap();
+    protocol.deposit("alice", "XLM", 5_000_000, 0).unwrap();
+    protocol
+        .borrow("alice", "USDC", 4_000_000, &oracle, 0)
+        .unwrap();
+
+    // Accrue one year with the original 10 % reserve factor.
+    protocol.accrue_interest("USDC", 31_536_000).unwrap();
+    let fees_low_rf = protocol.reserve_state("USDC").unwrap().protocol_fees;
+
+    // Reset state by creating a fresh protocol with a 50 % reserve factor.
+    let mut protocol2 = LendingProtocol::new("admin", "treasury", InterestRateModel::default());
+    let mut cfg = reserve("USDC", 9_000);
+    cfg.reserve_factor_bps = 5_000; // 50 %
+    protocol2.register_asset("admin", cfg, 0).unwrap();
+    protocol2
+        .register_asset("admin", reserve("XLM", 8_000), 0)
+        .unwrap();
+
+    let mut oracle2 = PriceOracle::new("oracle");
+    oracle2.set_price("oracle", "XLM", WAD).unwrap();
+    oracle2.set_price("oracle", "USDC", WAD).unwrap();
+
+    protocol2.deposit("lp", "USDC", 5_000_000, 0).unwrap();
+    protocol2.deposit("alice", "XLM", 5_000_000, 0).unwrap();
+    protocol2
+        .borrow("alice", "USDC", 4_000_000, &oracle2, 0)
+        .unwrap();
+    protocol2.accrue_interest("USDC", 31_536_000).unwrap();
+    let fees_high_rf = protocol2.reserve_state("USDC").unwrap().protocol_fees;
+
+    assert!(
+        fees_high_rf > fees_low_rf,
+        "50 % reserve factor ({fees_high_rf}) should collect more fees than 10 % ({fees_low_rf})"
+    );
+}
+
+#[test]
+fn set_reserve_factor_updates_config_and_affects_future_accrual() {
+    let (mut protocol, oracle) = setup_protocol();
+
+    protocol.deposit("lp", "USDC", 5_000_000, 0).unwrap();
+    protocol.deposit("alice", "XLM", 5_000_000, 0).unwrap();
+    protocol
+        .borrow("alice", "USDC", 4_000_000, &oracle, 0)
+        .unwrap();
+
+    // Raise the reserve factor to 50 % mid-flight.
+    protocol.set_reserve_factor("admin", "USDC", 5_000).unwrap();
+
+    // Accrue interest — the new factor should apply.
+    protocol.accrue_interest("USDC", 31_536_000).unwrap();
+    let fees = protocol.reserve_state("USDC").unwrap().protocol_fees;
+    assert!(fees > 0, "protocol fees should be positive after accrual");
+}
+
+#[test]
+fn set_reserve_factor_rejects_value_above_10000_bps() {
+    let (mut protocol, _oracle) = setup_protocol();
+
+    let err = protocol
+        .set_reserve_factor("admin", "USDC", 10_001)
+        .unwrap_err();
+    assert_eq!(err, ProtocolError::InvalidReserveFactor);
+}
+
+#[test]
+fn non_admin_cannot_set_reserve_factor() {
+    let (mut protocol, _oracle) = setup_protocol();
+
+    let err = protocol
+        .set_reserve_factor("alice", "USDC", 2_000)
+        .unwrap_err();
+    assert_eq!(err, ProtocolError::Unauthorized);
 }


### PR DESCRIPTION
closes #35 
closes #36 
closes #37 
closes #38 

Implements four enhancements to the lending protocol:

## Changes

### Per-asset interest rate models
- Added `interest_rate_model: Option<InterestRateModel>` to `ReserveConfig`
- Each asset can now override the protocol-level default IRM
- New admin methods: `set_asset_interest_rate_model()`, `set_default_interest_rate_model()`
- New query method: `interest_rate_model_for()`
- `accrue_interest()` resolves the correct model per asset at runtime

### Supply caps
- Added `supply_cap: i128` to `ReserveConfig` (0 = uncapped)
- `deposit()` rejects transactions that would exceed the cap with `SupplyCapExceeded`
- New admin method: `set_supply_cap()`

### Borrow caps
- Added `borrow_cap: i128` to `ReserveConfig` (0 = uncapped)
- `borrow()` rejects transactions that would exceed the cap with `BorrowCapExceeded`
- New admin method: `set_borrow_cap()`

### Dynamic reserve factors
- New admin method: `set_reserve_factor()` to update `reserve_factor_bps` on any live reserve
- Validates input is within 0–10 000 bps, returns `InvalidReserveFactor` otherwise
- Takes effect on the next `accrue_interest()` call

## Tests
- 13 new integration tests covering all four features
- Happy paths, cap enforcement, access control, and edge cases
- All 8 existing tests preserved and updated
