### PR TITLE
feat: add price update threshold to save gas

### DIFF
--- a/src/contracts/price_oracle.rs
+++ b/src/contracts/price_oracle.rs
@@ -24,6 +24,8 @@ const MIN_PRICE_SOURCES: u32 = 3;
 const MAX_PRICE_AGE: u64 = 3600;
 /// Heartbeat interval for price updates (5 minutes)
 const HEARTBEAT_INTERVAL: u64 = 300;
+/// Default price update threshold (0.5% or 50 basis points)
+const DEFAULT_PRICE_UPDATE_THRESHOLD_BPS: u32 = 50;
 
 // ─── Storage Keys ─────────────────────────────────────────────────────────────
 
@@ -34,6 +36,7 @@ const PRICES: Symbol = Symbol::short("PRICES");
 const PRICE_HISTORY: Symbol = Symbol::short("PRICEHIST");
 const DEVIATION_ALERTS: Symbol = Symbol::short("DEVIATE");
 const LAST_UPDATE: Symbol = Symbol::short("LASTUPD");
+const PRICE_UPDATE_THRESHOLD: Symbol = Symbol::short("UPDTHRES");
 
 // ─── Price Source Information ─────────────────────────────────────────────────
 
@@ -87,6 +90,7 @@ impl PriceOracleContract {
 
         env.storage().instance().set(&ADMIN, &admin);
         env.storage().instance().set(&PAUSED, &false);
+        env.storage().instance().set(&PRICE_UPDATE_THRESHOLD, &DEFAULT_PRICE_UPDATE_THRESHOLD_BPS);
         
         // Initialize empty storage
         let price_sources: Map<Address, PriceSource> = Map::new(&env);
@@ -178,6 +182,32 @@ impl PriceOracleContract {
             panic!("Price source is not active");
         }
         
+        // Check if price change exceeds threshold before updating storage
+        let threshold = Self::get_threshold(&env);
+        let source_prices_key = (source_address.clone(), asset_address.clone());
+        
+        // Check existing price from this source
+        let should_update = if let Some(existing_price) = env.storage().temporary().get::<_, OraclePrice>(&source_prices_key) {
+            let deviation = Self::calculate_price_deviation(existing_price.price, price);
+            deviation >= threshold
+        } else {
+            // No existing price, always update
+            true
+        };
+        
+        if !should_update {
+            // Price change below threshold, skip storage update but still track statistics
+            source.last_update = env.ledger().timestamp();
+            price_sources.set(source_address, source);
+            env.storage().instance().set(&PRICE_SOURCES, &price_sources);
+            
+            env.events().publish(
+                (Symbol::short("PRICE_UPDATE_SKIPPED"), source_address),
+                (asset_address, price, threshold),
+            );
+            return;
+        }
+        
         // Create new price entry
         let oracle_price = OraclePrice {
             asset_address: asset_address.clone(),
@@ -187,7 +217,6 @@ impl PriceOracleContract {
         };
         
         // Store price from this source
-        let source_prices_key = (source_address.clone(), asset_address.clone());
         env.storage().temporary().set(&source_prices_key, &oracle_price);
         
         // Update source statistics
@@ -361,6 +390,33 @@ impl PriceOracleContract {
         );
     }
 
+    /// Set price update threshold (admin only)
+    /// 
+    /// # Arguments
+    /// * `new_threshold_bps` - New threshold in basis points (0-10000)
+    /// 
+    /// Only updates prices when they change by this percentage or more.
+    /// For example, 50 basis points = 0.5% threshold.
+    pub fn set_price_update_threshold(env: Env, new_threshold_bps: u32) {
+        Self::require_admin(&env);
+        
+        if new_threshold_bps > 10000 {
+            panic!("Invalid threshold: must be between 0 and 10000 basis points");
+        }
+        
+        env.storage().instance().set(&PRICE_UPDATE_THRESHOLD, &new_threshold_bps);
+        
+        env.events().publish(
+            Symbol::short("THRESHOLD_UPDATED"),
+            new_threshold_bps,
+        );
+    }
+
+    /// Get current price update threshold
+    pub fn get_price_update_threshold(env: Env) -> u32 {
+        Self::get_threshold(&env)
+    }
+
     // ─── Internal Functions ─────────────────────────────────────────────────────
 
     fn aggregate_price(env: &Env, asset_address: Address) {
@@ -397,13 +453,15 @@ impl PriceOracleContract {
             .map(|(price, _)| price.decimals)
             .unwrap_or(6);
         
-        // Check for price deviation
-        if let Some(current_price) = Self::get_prices(env).get(asset_address.clone()) {
+        // Check if aggregated price change exceeds threshold before updating storage
+        let threshold = Self::get_threshold(env);
+        let should_update = if let Some(current_price) = Self::get_prices(env).get(asset_address.clone()) {
             let deviation = Self::calculate_price_deviation(
                 current_price.price,
                 aggregated_price,
             );
             
+            // Check for price deviation alert
             if deviation > MAX_PRICE_DEVIATION_BPS {
                 Self::create_deviation_alert(
                     env,
@@ -413,6 +471,21 @@ impl PriceOracleContract {
                     deviation,
                 );
             }
+            
+            // Only update if change exceeds threshold
+            deviation >= threshold
+        } else {
+            // No existing price, always update
+            true
+        };
+        
+        if !should_update {
+            // Price change below threshold, skip storage update
+            env.events().publish(
+                (Symbol::short("AGGREGATION_SKIPPED"), asset_address.clone()),
+                (aggregated_price, threshold),
+            );
+            return;
         }
         
         // Store aggregated price
@@ -510,5 +583,9 @@ impl PriceOracleContract {
 
     fn get_price_history(env: &Env) -> Map<Address, Vec<PriceHistoryEntry>> {
         env.storage().instance().get(&PRICE_HISTORY).unwrap()
+    }
+
+    fn get_threshold(env: &Env) -> u32 {
+        env.storage().instance().get(&PRICE_UPDATE_THRESHOLD).unwrap()
     }
 }


### PR DESCRIPTION
Closes #45

---

- Add DEFAULT_PRICE_UPDATE_THRESHOLD_BPS constant (0.5%)
- Add PRICE_UPDATE_THRESHOLD storage key
- Initialize threshold in initialize()
- Modify update_price() to check threshold before storing
- Modify aggregate_price() to check threshold before storing
- Add set_price_update_threshold() admin function
- Add get_price_update_threshold() public function
- Emit PRICE_UPDATE_SKIPPED and AGGREGATION_SKIPPED events

This implementation saves gas by only updating prices when they change by more than the configured threshold, reducing unnecessary storage writes.