### PR TITLE
fix: complete transfer_from with allowance check, balance update, and event (fixes #17)

### DIFF
--- a/src/contracts/token.rs
+++ b/src/contracts/token.rs
@@ -16,29 +16,6 @@ fn allowance_key(env: &Env, owner: &Address, spender: &Address) -> soroban_sdk::
     key.append(&soroban_sdk::Bytes::from_slice(env, b":"));
     key.append(&spender.clone().to_string().into_bytes(env));
     key
-use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec};
-use soroban_token_sdk::{Token, TokenInterface};
-use crate::types::token::{TokenInfo, TokenMetadata};
-use crate::utils::StellarClient;
-use std::collections::HashMap;
-
-/// Token contract implementing standard token functionality
-#[contract]
-pub struct TokenContract {
-    /// Token name
-    name: String,
-    /// Token symbol
-    symbol: String,
-    /// Total supply
-    total_supply: u64,
-    /// Token decimals
-    decimals: u8,
-    /// Contract address
-    address: Option<Address>,
-    /// Balances per address (address string -> balance)
-    balances: HashMap<String, u64>,
-    /// Allowances: owner -> spender -> amount
-    allowances: HashMap<String, HashMap<String, u64>>,
 }
 
 #[contract]
@@ -46,265 +23,78 @@ pub struct TokenContract;
 
 #[contractimpl]
 impl TokenContract {
-    /// Initialize the contract and set the admin
+    /// Initialize the contract and set the admin.
     pub fn initialize(env: Env, admin: Address) {
         env.storage().instance().set(&ADMIN_KEY, &admin);
-    /// Create a new token contract
-    pub fn new(name: String, symbol: String, initial_supply: u64) -> Self {
-        Self {
-            name,
-            symbol,
-            total_supply: initial_supply,
-            decimals: 7, // Stellar standard
-            address: None,
-            balances: HashMap::new(),
-            allowances: HashMap::new(),
-        }
     }
 
-    /// Returns the balance of the given address using persistent storage
+    /// Returns the balance of `owner`.
     pub fn balance_of(env: Env, owner: Address) -> i128 {
         let key = balance_key(&env, &owner);
         env.storage().persistent().get(&key).unwrap_or(0)
     }
 
-    /// Returns the allowance that `spender` is allowed to spend on behalf of `owner`
+    /// Returns the allowance that `spender` may spend on behalf of `owner`.
     pub fn allowance(env: Env, owner: Address, spender: Address) -> i128 {
         let key = allowance_key(&env, &owner, &spender);
         env.storage().persistent().get(&key).unwrap_or(0)
     }
 
-    /// Approve `spender` to spend up to `amount` tokens on behalf of the caller
+    /// Approve `spender` to spend up to `amount` tokens on behalf of `owner`.
     pub fn approve(env: Env, owner: Address, spender: Address, amount: i128) {
         owner.require_auth();
         let key = allowance_key(&env, &owner, &spender);
         env.storage().persistent().set(&key, &amount);
+        env.events().publish(
+            (symbol_short!("approval"), owner, spender),
+            amount,
+        );
     }
 
-    /// Transfer tokens from the caller to `to`
+    /// Transfer `amount` tokens from `from` to `to`. Caller must be `from`.
     pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
         from.require_auth();
         let from_balance = Self::balance_of(env.clone(), from.clone());
         assert!(from_balance >= amount, "Insufficient balance");
 
-        let from_key = balance_key(&env, &from);
-        let to_key = balance_key(&env, &to);
-
         let to_balance = Self::balance_of(env.clone(), to.clone());
-        env.storage().persistent().set(&from_key, &(from_balance - amount));
-        env.storage().persistent().set(&to_key, &(to_balance + amount));
+        env.storage().persistent().set(&balance_key(&env, &from), &(from_balance - amount));
+        env.storage().persistent().set(&balance_key(&env, &to), &(to_balance + amount));
+
+        env.events().publish(
+            (symbol_short!("transfer"), from, to),
+            amount,
+        );
     }
 
-    /// Transfer tokens on behalf of `from` using an allowance
+    /// Transfer `amount` tokens from `from` to `to` using `spender`'s allowance.
     pub fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128) {
         spender.require_auth();
+
+        // 1. Check and deduct allowance
         let current_allowance = Self::allowance(env.clone(), from.clone(), spender.clone());
         assert!(current_allowance >= amount, "Insufficient allowance");
+        env.storage().persistent().set(
+            &allowance_key(&env, &from, &spender),
+            &(current_allowance - amount),
+        );
 
-        // Reduce allowance
-        let allow_key = allowance_key(&env, &from, &spender);
-        env.storage().persistent().set(&allow_key, &(current_allowance - amount));
-
-        // Execute transfer
+        // 2. Check and update balances
         let from_balance = Self::balance_of(env.clone(), from.clone());
         assert!(from_balance >= amount, "Insufficient balance");
-    /// Mint new tokens
-    pub fn mint(&mut self, to: Address, amount: u64) -> Result<(), String> {
-        if amount == 0 {
-            return Err("Amount must be greater than 0".to_string());
-        }
-
-        self.total_supply = self.total_supply
-            .checked_add(amount)
-            .ok_or("Overflow: total supply exceeded u64::MAX")?;
-
-        let key = to.to_string();
-        let entry = self.balances.entry(key).or_insert(0);
-        *entry = entry.checked_add(amount).ok_or("Overflow: balance exceeded u64::MAX")?;
-
-        Ok(())
-    }
-
-    /// Burn tokens
-    pub fn burn(&mut self, from: Address, amount: u64) -> Result<(), String> {
-        if amount == 0 {
-            return Err("Amount must be greater than 0".to_string());
-        }
-
-        if self.total_supply < amount {
-            return Err("Insufficient supply to burn".to_string());
-        }
-
-        let key = from.to_string();
-        let balance = self.balances.get(&key).copied().unwrap_or(0);
-        if balance < amount {
-            return Err("Insufficient balance to burn".to_string());
-        }
-
-        self.total_supply -= amount;
-        *self.balances.entry(key).or_insert(0) -= amount;
-
-        Ok(())
-    }
-
-    /// Transfer tokens between addresses
-    ///
-    /// Fixes issue #15: implements full transfer logic including balance check,
-    /// deducting from sender, crediting receiver, and emitting a Transfer event.
-    pub fn transfer(&mut self, from: Address, to: Address, amount: u64) -> Result<(), String> {
-        if amount == 0 {
-            return Err("Amount must be greater than 0".to_string());
-        }
-
-        if from == to {
-            return Err("Cannot transfer to the same address".to_string());
-        }
-
-        let from_key = from.to_string();
-        let to_key = to.to_string();
-
-        // 1. Check sender's balance
-        let sender_balance = self.balances.get(&from_key).copied().unwrap_or(0);
-        if sender_balance < amount {
-            return Err(format!(
-                "Insufficient balance: sender has {}, tried to send {}",
-                sender_balance, amount
-            ));
-        }
-
-        // 2. Subtract amount from sender
-        *self.balances.entry(from_key.clone()).or_insert(0) -= amount;
-
-        // 3. Add amount to receiver
-        let receiver_entry = self.balances.entry(to_key.clone()).or_insert(0);
-        *receiver_entry = receiver_entry
-            .checked_add(amount)
-            .ok_or("Overflow: receiver balance exceeded u64::MAX")?;
-
-        // 4. Emit Transfer event (logged as a structured record)
-        self.emit_transfer_event(&from_key, &to_key, amount);
-
-        Ok(())
-    }
-
-    /// Get balance of an address
-    pub fn balance_of(&self, address: Address) -> u64 {
-        self.balances.get(&address.to_string()).copied().unwrap_or(0)
-    }
-
-    /// Approve spending for another address
-    ///
-    /// Fixes issue #16: implements full approval logic including storing the
-    /// allowance and emitting an Approval event.
-    pub fn approve(&mut self, owner: Address, spender: Address, amount: u64) -> Result<(), String> {
-        if amount == 0 {
-            return Err("Amount must be greater than 0".to_string());
-        }
-
-        let owner_key = owner.to_string();
-        let spender_key = spender.to_string();
-
-        // 1. Store the allowance: owner -> spender -> amount
-        self.allowances
-            .entry(owner_key.clone())
-            .or_insert_with(HashMap::new)
-            .insert(spender_key.clone(), amount);
-
-        // 2. Emit Approval event
-        self.emit_approval_event(&owner_key, &spender_key, amount);
-
-        Ok(())
-    }
-
-    /// Get allowance for a spender
-    pub fn allowance(&self, owner: Address, spender: Address) -> u64 {
-        self.allowances
-            .get(&owner.to_string())
-            .and_then(|m| m.get(&spender.to_string()))
-            .copied()
-            .unwrap_or(0)
-    }
-
-    /// Transfer from approved address
-    pub fn transfer_from(
-        &mut self,
-        spender: Address,
-        from: Address,
-        to: Address,
-        amount: u64,
-    ) -> Result<(), String> {
-        if amount == 0 {
-            return Err("Amount must be greater than 0".to_string());
-        }
-
-        let from_key = from.to_string();
-        let spender_key = spender.to_string();
-
-        // 1. Check allowance
-        let current_allowance = self
-            .allowances
-            .get(&from_key)
-            .and_then(|m| m.get(&spender_key))
-            .copied()
-            .unwrap_or(0);
-
-        if current_allowance < amount {
-            return Err(format!(
-                "Insufficient allowance: spender has {}, tried to spend {}",
-                current_allowance, amount
-            ));
-        }
-
-        // 2. Perform transfer (reuses transfer logic)
-        self.transfer(from.clone(), to, amount)?;
-
-        // 3. Update allowance
-        if let Some(owner_allowances) = self.allowances.get_mut(&from_key) {
-            if let Some(allowance) = owner_allowances.get_mut(&spender_key) {
-                *allowance -= amount;
-            }
-        }
-
-        Ok(())
-    }
-
-    // -------------------------------------------------------------------------
-    // Internal event helpers
-    // -------------------------------------------------------------------------
-
-    /// Emit a Transfer event (structured log; in Soroban this would call env.events().publish())
-    fn emit_transfer_event(&self, from: &str, to: &str, amount: u64) {
-        // In a live Soroban contract this becomes:
-        //   env.events().publish((symbol_short!("transfer"), from, to), amount);
-        // Here we use a structured log so the event is visible in test output.
-        println!(
-            "[Event] Transfer {{ from: {}, to: {}, amount: {} }}",
-            from, to, amount
-        );
-    }
-
-    /// Emit an Approval event (structured log; in Soroban this would call env.events().publish())
-    fn emit_approval_event(&self, owner: &str, spender: &str, amount: u64) {
-        // In a live Soroban contract this becomes:
-        //   env.events().publish((symbol_short!("approval"), owner, spender), amount);
-        println!(
-            "[Event] Approval {{ owner: {}, spender: {}, amount: {} }}",
-            owner, spender, amount
-        );
-    }
-}
-
-        let from_key = balance_key(&env, &from);
-        let to_key = balance_key(&env, &to);
         let to_balance = Self::balance_of(env.clone(), to.clone());
+        env.storage().persistent().set(&balance_key(&env, &from), &(from_balance - amount));
+        env.storage().persistent().set(&balance_key(&env, &to), &(to_balance + amount));
 
-        env.storage().persistent().set(&from_key, &(from_balance - amount));
-        env.storage().persistent().set(&to_key, &(to_balance + amount));
+        // 3. Emit Transfer event
+        env.events().publish(
+            (symbol_short!("transfer"), from, to),
+            amount,
+        );
     }
 
-    /// Mint new tokens to `to` — admin only
+    /// Mint `amount` tokens to `to`. Admin only.
     pub fn mint(env: Env, to: Address, amount: i128) {
-        // Enforce admin-only access
         let admin: Address = env.storage().instance().get(&ADMIN_KEY)
             .expect("Contract not initialized");
         admin.require_auth();
@@ -312,41 +102,12 @@ impl TokenContract {
         let key = balance_key(&env, &to);
         let current = Self::balance_of(env.clone(), to.clone());
         env.storage().persistent().set(&key, &(current + amount));
-    #[test]
-    fn test_mint() {
-        let mut token = TokenContract::new("Test Token".to_string(), "TEST".to_string(), 1000000);
-        let address = Address::generate(&Env::default());
-        
-        let initial_supply = token.total_supply;
-        token.mint(address.clone(), 500000).unwrap();
-        
-        assert_eq!(token.total_supply, initial_supply + 500000);
-        // Minted tokens should appear in the recipient's balance
-        assert_eq!(token.balance_of(address), 500000);
     }
 
-    #[test]
-    fn test_burn() {
-        let mut token = TokenContract::new("Test Token".to_string(), "TEST".to_string(), 1000000);
-        let address = Address::generate(&Env::default());
-
-        // Give the address some balance first
-        token.mint(address.clone(), 200000).unwrap();
-        let supply_after_mint = token.total_supply;
-
-        token.burn(address.clone(), 100000).unwrap();
-        
-        assert_eq!(token.total_supply, supply_after_mint - 100000);
-        assert_eq!(token.balance_of(address), 100000);
-    }
-
-    /// Burn tokens from `from` — caller must be the token holder or admin
+    /// Burn `amount` tokens from `from`. Caller must be `from` or the admin.
     pub fn burn(env: Env, from: Address, amount: i128) {
-        // Enforce that either the holder or the admin is authorizing the burn
         let admin: Address = env.storage().instance().get(&ADMIN_KEY)
             .expect("Contract not initialized");
-
-        // Require auth from either the holder (self-burn) or the admin
         if from != admin {
             from.require_auth();
         } else {
@@ -355,152 +116,151 @@ impl TokenContract {
 
         let current = Self::balance_of(env.clone(), from.clone());
         assert!(current >= amount, "Insufficient balance to burn");
-
-        let key = balance_key(&env, &from);
-        env.storage().persistent().set(&key, &(current - amount));
+        env.storage().persistent().set(&balance_key(&env, &from), &(current - amount));
     }
 
-    /// Get the current admin address
+    /// Returns the current admin address.
     pub fn get_admin(env: Env) -> Address {
         env.storage().instance().get(&ADMIN_KEY)
             .expect("Contract not initialized")
     }
+}
 
-    // -------------------------------------------------------------------------
-    // Issue #15 – Transfer tests
-    // -------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
 
-    #[test]
-    fn test_transfer_success() {
+    fn setup() -> (Env, soroban_sdk::Address, TokenContractClient<'static>) {
         let env = Env::default();
-        let mut token = TokenContract::new("Test Token".to_string(), "TEST".to_string(), 0);
-        let sender = Address::generate(&env);
-        let receiver = Address::generate(&env);
-
-        // Fund sender
-        token.mint(sender.clone(), 1000).unwrap();
-        assert_eq!(token.balance_of(sender.clone()), 1000);
-
-        // Transfer 400 to receiver
-        token.transfer(sender.clone(), receiver.clone(), 400).unwrap();
-
-        assert_eq!(token.balance_of(sender), 600);
-        assert_eq!(token.balance_of(receiver), 400);
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, TokenContract);
+        let client = TokenContractClient::new(&env, &contract_id);
+        let admin = soroban_sdk::Address::generate(&env);
+        client.initialize(&admin);
+        // Leak env for 'static lifetime required by Client — acceptable in tests
+        let env: &'static Env = Box::leak(Box::new(env));
+        let client = TokenContractClient::new(env, &contract_id);
+        (env.clone(), admin, client)
     }
 
     #[test]
+    fn test_mint_and_balance() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, TokenContract);
+        let client = TokenContractClient::new(&env, &contract_id);
+        let admin = soroban_sdk::Address::generate(&env);
+        client.initialize(&admin);
+
+        let user = soroban_sdk::Address::generate(&env);
+        client.mint(&user, &1_000);
+        assert_eq!(client.balance_of(&user), 1_000);
+    }
+
+    #[test]
+    fn test_transfer() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, TokenContract);
+        let client = TokenContractClient::new(&env, &contract_id);
+        let admin = soroban_sdk::Address::generate(&env);
+        client.initialize(&admin);
+
+        let sender = soroban_sdk::Address::generate(&env);
+        let receiver = soroban_sdk::Address::generate(&env);
+        client.mint(&sender, &1_000);
+
+        client.transfer(&sender, &receiver, &400);
+        assert_eq!(client.balance_of(&sender), 600);
+        assert_eq!(client.balance_of(&receiver), 400);
+    }
+
+    #[test]
+    #[should_panic(expected = "Insufficient balance")]
     fn test_transfer_insufficient_balance() {
         let env = Env::default();
-        let mut token = TokenContract::new("Test Token".to_string(), "TEST".to_string(), 0);
-        let sender = Address::generate(&env);
-        let receiver = Address::generate(&env);
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, TokenContract);
+        let client = TokenContractClient::new(&env, &contract_id);
+        let admin = soroban_sdk::Address::generate(&env);
+        client.initialize(&admin);
 
-        token.mint(sender.clone(), 100).unwrap();
-
-        let result = token.transfer(sender, receiver, 500);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Insufficient balance"));
+        let sender = soroban_sdk::Address::generate(&env);
+        let receiver = soroban_sdk::Address::generate(&env);
+        client.mint(&sender, &100);
+        client.transfer(&sender, &receiver, &500);
     }
 
     #[test]
-    fn test_transfer_zero_amount() {
+    fn test_approve_and_allowance() {
         let env = Env::default();
-        let mut token = TokenContract::new("Test Token".to_string(), "TEST".to_string(), 0);
-        let sender = Address::generate(&env);
-        let receiver = Address::generate(&env);
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, TokenContract);
+        let client = TokenContractClient::new(&env, &contract_id);
+        let admin = soroban_sdk::Address::generate(&env);
+        client.initialize(&admin);
 
-        let result = token.transfer(sender, receiver, 0);
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), "Amount must be greater than 0");
-    }
-
-    #[test]
-    fn test_transfer_to_same_address() {
-        let env = Env::default();
-        let mut token = TokenContract::new("Test Token".to_string(), "TEST".to_string(), 0);
-        let addr = Address::generate(&env);
-
-        token.mint(addr.clone(), 500).unwrap();
-
-        let result = token.transfer(addr.clone(), addr, 100);
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), "Cannot transfer to the same address");
-    }
-
-    // -------------------------------------------------------------------------
-    // Issue #16 – Approve tests
-    // -------------------------------------------------------------------------
-
-    #[test]
-    fn test_approve_stores_allowance() {
-        let env = Env::default();
-        let mut token = TokenContract::new("Test Token".to_string(), "TEST".to_string(), 0);
-        let owner = Address::generate(&env);
-        let spender = Address::generate(&env);
-
-        token.approve(owner.clone(), spender.clone(), 300).unwrap();
-
-        assert_eq!(token.allowance(owner, spender), 300);
-    }
-
-    #[test]
-    fn test_approve_zero_amount() {
-        let env = Env::default();
-        let mut token = TokenContract::new("Test Token".to_string(), "TEST".to_string(), 0);
-        let owner = Address::generate(&env);
-        let spender = Address::generate(&env);
-
-        let result = token.approve(owner, spender, 0);
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), "Amount must be greater than 0");
-    }
-
-    #[test]
-    fn test_approve_overwrite_allowance() {
-        let env = Env::default();
-        let mut token = TokenContract::new("Test Token".to_string(), "TEST".to_string(), 0);
-        let owner = Address::generate(&env);
-        let spender = Address::generate(&env);
-
-        token.approve(owner.clone(), spender.clone(), 300).unwrap();
-        token.approve(owner.clone(), spender.clone(), 150).unwrap();
-
-        // Second approval should overwrite the first
-        assert_eq!(token.allowance(owner, spender), 150);
+        let owner = soroban_sdk::Address::generate(&env);
+        let spender = soroban_sdk::Address::generate(&env);
+        client.approve(&owner, &spender, &300);
+        assert_eq!(client.allowance(&owner, &spender), 300);
     }
 
     #[test]
     fn test_transfer_from_success() {
         let env = Env::default();
-        let mut token = TokenContract::new("Test Token".to_string(), "TEST".to_string(), 0);
-        let owner = Address::generate(&env);
-        let spender = Address::generate(&env);
-        let receiver = Address::generate(&env);
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, TokenContract);
+        let client = TokenContractClient::new(&env, &contract_id);
+        let admin = soroban_sdk::Address::generate(&env);
+        client.initialize(&admin);
 
-        token.mint(owner.clone(), 1000).unwrap();
-        token.approve(owner.clone(), spender.clone(), 500).unwrap();
+        let owner = soroban_sdk::Address::generate(&env);
+        let spender = soroban_sdk::Address::generate(&env);
+        let receiver = soroban_sdk::Address::generate(&env);
 
-        token.transfer_from(spender.clone(), owner.clone(), receiver.clone(), 200).unwrap();
+        client.mint(&owner, &1_000);
+        client.approve(&owner, &spender, &500);
 
-        assert_eq!(token.balance_of(owner.clone()), 800);
-        assert_eq!(token.balance_of(receiver), 200);
-        // Allowance should be reduced
-        assert_eq!(token.allowance(owner, spender), 300);
+        client.transfer_from(&spender, &owner, &receiver, &200);
+
+        assert_eq!(client.balance_of(&owner), 800);
+        assert_eq!(client.balance_of(&receiver), 200);
+        assert_eq!(client.allowance(&owner, &spender), 300);
     }
 
     #[test]
+    #[should_panic(expected = "Insufficient allowance")]
     fn test_transfer_from_insufficient_allowance() {
         let env = Env::default();
-        let mut token = TokenContract::new("Test Token".to_string(), "TEST".to_string(), 0);
-        let owner = Address::generate(&env);
-        let spender = Address::generate(&env);
-        let receiver = Address::generate(&env);
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, TokenContract);
+        let client = TokenContractClient::new(&env, &contract_id);
+        let admin = soroban_sdk::Address::generate(&env);
+        client.initialize(&admin);
 
-        token.mint(owner.clone(), 1000).unwrap();
-        token.approve(owner.clone(), spender.clone(), 50).unwrap();
+        let owner = soroban_sdk::Address::generate(&env);
+        let spender = soroban_sdk::Address::generate(&env);
+        let receiver = soroban_sdk::Address::generate(&env);
 
-        let result = token.transfer_from(spender, owner, receiver, 200);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Insufficient allowance"));
+        client.mint(&owner, &1_000);
+        client.approve(&owner, &spender, &50);
+        client.transfer_from(&spender, &owner, &receiver, &200);
+    }
+
+    #[test]
+    fn test_burn() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, TokenContract);
+        let client = TokenContractClient::new(&env, &contract_id);
+        let admin = soroban_sdk::Address::generate(&env);
+        client.initialize(&admin);
+
+        let user = soroban_sdk::Address::generate(&env);
+        client.mint(&user, &1_000);
+        client.burn(&user, &400);
+        assert_eq!(client.balance_of(&user), 600);
     }
 }


### PR DESCRIPTION
Resolves issue #17 by merging ComputerOracle's fix from PR #89.

The transfer_from function now:
1. Checks and deducts allowance
2. Checks and updates balances
3. Emits Transfer event via env.events().publish()

Additionally, the file was consolidated into a single canonical Soroban #[contract] implementation, removing duplicate struct definitions, duplicate use statements, and missing closing braces.

Closes #17