### PR TITLE
Add access control matrix, security audit checklist, and architecture…

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,71 @@
+# Security Policy
+
+Stellar DeFi Toolkit contracts hold or route user funds. If you find a
+vulnerability, please report it privately rather than opening a public issue or
+pull request — public disclosure before a fix ships can put user funds at risk.
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for a security vulnerability.**
+
+Instead, use GitHub's private vulnerability reporting for this repository:
+[Security Advisories → Report a vulnerability](../../security/advisories/new).
+If that's unavailable to you, contact a maintainer directly through a private
+channel (e.g. a direct message) rather than a public issue, PR comment, or
+Discord channel.
+
+Please include:
+
+- A description of the vulnerability and its potential impact
+- The affected contract(s) and function(s) — cross-reference
+  [`docs/ACCESS_CONTROL_MATRIX.md`](../docs/ACCESS_CONTROL_MATRIX.md) if it maps to a
+  known access-control gap
+- Steps to reproduce, or a minimal proof-of-concept (test case, script, or
+  transaction trace)
+- Any suggested remediation, if you have one
+
+## What to Expect
+
+- **Acknowledgment:** we aim to acknowledge new reports within 3 business days.
+- **Triage:** we'll assess severity using the categories in
+  [`docs/SECURITY_AUDIT_CHECKLIST.md`](../docs/SECURITY_AUDIT_CHECKLIST.md)
+  (reentrancy, oracle manipulation, flash loan attacks, governance attacks, access
+  control, and standard DoS/overflow classes) and confirm whether it's a new finding
+  or already tracked in that document's known-findings appendix.
+- **Fix and disclosure:** once a fix is merged (or a mitigation is in place), we'll
+  coordinate on public disclosure timing with the reporter. We do not have a bug
+  bounty program at this time, but we will credit reporters (with permission) in
+  release notes.
+
+## Scope
+
+In scope:
+
+- All contracts under `src/contracts/`, `governance/`, and `staking/`
+- Access control and authentication logic
+- Oracle price aggregation and consumption
+- Arithmetic in fee, interest, collateral-ratio, and reward calculations
+- Governance proposal/voting/execution logic
+
+Out of scope:
+
+- Issues already listed in
+  [`docs/SECURITY_AUDIT_CHECKLIST.md` Appendix A](../docs/SECURITY_AUDIT_CHECKLIST.md#appendix-a-current-known-findings-by-severity)
+  — these are known and tracked; feel free to reference them, but they don't need a
+  fresh private report.
+- The CLI (`src/main.rs`, `cli/`) and example code (`examples/`), unless the issue
+  demonstrates a path back into contract state or fund custody.
+- Denial of service against third-party infrastructure (RPC providers, Horizon, etc.)
+  rather than this codebase.
+
+## Supported Versions
+
+This project is pre-1.0 and does not yet maintain multiple supported release
+branches. Security fixes land on `main`; there is no backport policy until a 1.0
+release establishes one.
+
+## Review Cadence
+
+Beyond ad hoc reports, the protocol's overall attack surface is reviewed quarterly
+per the cadence defined in
+[`docs/SECURITY_AUDIT_CHECKLIST.md`](../docs/SECURITY_AUDIT_CHECKLIST.md#4-review-cadence).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,6 +206,53 @@ pub async fn deploy(&self, client: &StellarClient) -> Result<String> {
 - Include usage examples
 - Add new features to the features list
 
+## 🔐 Access Control & Permission Documentation
+
+Every contract in `src/contracts/` is documented in
+[`docs/ACCESS_CONTROL_MATRIX.md`](docs/ACCESS_CONTROL_MATRIX.md), which maps
+**Contract × Role × Action** for the whole protocol. The four roles are:
+
+- **Admin** — a single privileged address managing parameters, pausing, and
+  emergency actions for a contract.
+- **Governance** — token-weighted voting participants (proposers, voters, executors).
+- **Keeper** — a permissionless or semi-permissionless automated caller (bot, oracle
+  feeder, liquidator, arbitrageur).
+- **User** — any account interacting with the protocol on its own behalf.
+
+If your change adds, removes, or changes who can call a function:
+
+1. **Update `docs/ACCESS_CONTROL_MATRIX.md`** — add/edit the row for that function in
+   the relevant contract's table, and update the role capability rollup sections if
+   the change is significant.
+2. **Add or update the module-level `## Access Control` doc comment** at the top of
+   the contract file (see any file in `src/contracts/` for the established format —
+   e.g. `staking.rs` or `stability_pool.rs`). This keeps a short, accurate summary next
+   to the code, while the matrix stays the canonical, cross-contract reference.
+3. **State enforcement, not just intent.** Document what the code actually does
+   (e.g. "no `require_auth()` call" or "gated by a broken admin check"), not just what
+   the function name or a stale comment implies. The matrix is only useful if it
+   reflects reality — inaccurate access-control docs are worse than none.
+4. If your change *fixes* a broken or missing auth check, update the corresponding
+   row(s) and the [Enforcement Gap Appendix](docs/ACCESS_CONTROL_MATRIX.md#appendix-enforcement-gaps-found-during-this-audit)
+   to mark the finding resolved.
+
+## 🛡️ Security
+
+Before opening a PR that touches fund-handling logic (minting, burning, transfers,
+collateral, liquidations, oracle prices, or governance execution), review
+[`docs/SECURITY_AUDIT_CHECKLIST.md`](docs/SECURITY_AUDIT_CHECKLIST.md) and the threat
+model it contains. At minimum:
+
+- Walk through the reentrancy, overflow, oracle-manipulation, governance-attack, and
+  flash-loan-attack checklist items relevant to your change.
+- Call out any new external calls, price dependencies, or privileged operations in
+  your PR description.
+- If your change touches an access-control check, cross-reference
+  `docs/ACCESS_CONTROL_MATRIX.md` (see previous section).
+
+To report a security vulnerability, follow the process in
+[`.github/SECURITY.md`](.github/SECURITY.md) rather than opening a public issue.
+
 ## 🔄 Pull Request Process
 
 1. **Create Pull Request**

--- a/README.md
+++ b/README.md
@@ -194,6 +194,21 @@ fn main() {
 
 For more details, see [STAKING_README.md](STAKING_README.md) and [docs/staking_contract.md](docs/staking_contract.md).
 
+## 🏛️ Architecture
+
+The toolkit is organized into five layers: an **oracle layer** for price discovery,
+a **core protocol layer** (lending, stablecoin, synthetic assets, liquidity pools,
+vaults, staking), a **safety layer** (circuit breakers, stability pool), a
+**governance layer**, and an **interface layer** (GraphQL API + CLI). See
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full component diagram, key
+module-interaction sequence diagrams (minting, liquidation, oracle aggregation,
+governance execution), the protocol-wide economic model with formulas, and a
+consolidated risk-parameter reference.
+
+Every contract's permission model — which roles (Admin, Governance, Keeper, User)
+can call which functions — is documented in
+[docs/ACCESS_CONTROL_MATRIX.md](docs/ACCESS_CONTROL_MATRIX.md).
+
 ## 🏗️ Project Structure
 
 ```
@@ -296,8 +311,12 @@ cargo run --example liquidity_pool
 
 ## 📚 Documentation
 
+- [Architecture Overview](docs/ARCHITECTURE.md) - Component diagram, interaction flows, economic model, risk parameters
+- [Access Control Matrix](docs/ACCESS_CONTROL_MATRIX.md) - Contract x Role x Action permission reference
+- [Security Audit Checklist & Threat Model](docs/SECURITY_AUDIT_CHECKLIST.md) - Attack surface inventory and pre-audit checklist
 - [Circuit Breaker Guide](docs/circuit_breaker_guide.md) - Price volatility protection
 - [Risk Management Framework](docs/synthetic_protocol_risk_management.md) - Comprehensive risk controls
+- [Stablecoin Economic Model](docs/stablecoin_economic_model.md) - Peg mechanism and parameters
 - [Soroban Documentation](https://soroban.stellar.org/)
 - [Stellar Documentation](https://developers.stellar.org/)
 - [API Reference](https://docs.rs/stellar-defi-toolkit/)

--- a/docs/ACCESS_CONTROL_MATRIX.md
+++ b/docs/ACCESS_CONTROL_MATRIX.md
@@ -1,0 +1,424 @@
+# Access Control Matrix
+
+This document is the single source of truth for **who can call what** across every
+contract in the toolkit. It maps **Contract × Role × Action**, and — critically —
+distinguishes between the **designed** permission model (what the code and comments
+intend) and the **as-enforced** behavior (what actually happens on-chain today).
+
+> **This distinction is not academic.** An initial audit pass performed while writing
+> this document found that a large share of "Admin only" and "User only" checks in this
+> codebase do not actually authenticate the caller (see
+> [Enforcement Gap Appendix](#appendix-enforcement-gaps-found-during-this-audit) and the
+> [Security Audit Checklist](SECURITY_AUDIT_CHECKLIST.md)). Treat every `⚠️ broken` tag
+> below as a live finding, not a hypothetical.
+
+## Roles
+
+| Role | Definition |
+|---|---|
+| **Admin** | A single privileged address, set once at `initialize()`, intended to manage protocol parameters, pausing, and emergency actions. |
+| **Governance** | Token-weighted voting participants (proposers, voters, executors) in the on-chain governance contracts. A superset of "User" scoped to proposal/vote actions. |
+| **Keeper** | A permissionless or semi-permissionless automated caller (bot, oracle feeder, liquidator, arbitrageur) that triggers time- or condition-sensitive operations. Anyone can act as a keeper; the role describes *function*, not identity. |
+| **User** | Any account interacting with the protocol on its own behalf (depositing, borrowing, minting, staking, swapping). |
+
+## How to read the "Enforcement" column
+
+- **✅ enforced** — the function calls `Address::require_auth()` on the relevant
+  identity, and (for Admin) compares it against the stored admin/role address.
+- **⚠️ broken** — the function *intends* to gate on a role, but the check does not
+  cryptographically authenticate the caller (most commonly: `require_admin()` compares
+  `env.current_contract_address()` to the stored admin instead of calling
+  `admin.require_auth()`), so the gate is either permanently unreachable or provides no
+  real protection.
+- **❌ none** — no auth check of any kind exists, though the parameter naming/doc intent
+  implies one role or another.
+- **— (view)** — read-only, no state change, open to anyone by design.
+
+---
+
+## Contract × Role × Action Matrix
+
+### `token.rs` — `TokenContract`
+
+Plain in-memory Rust struct, **not a deployed Soroban `#[contract]`** — no `Env`, no
+`require_auth` capability exists in this file at all.
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Mint tokens | `mint` | Admin | ❌ none |
+| Burn tokens | `burn` | User (self) | ❌ none |
+| Transfer | `transfer` | User (`from`) | ❌ none |
+| Approve allowance | `approve` | User (`owner`) | ❌ none |
+| Spend allowance | `transfer_from` | User (`spender`) | ❌ none |
+| Read balance / allowance / info | `balance_of`, `allowance`, `get_info` | Anyone | — (view) |
+
+### `soroban_token_contract.rs` — `SorobanTokenContract`
+
+The only token implementation with fully correct auth.
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize | `initialize` | Admin (self-declared) | ✅ enforced (`admin.require_auth()`) — but **no re-init guard**, callable repeatedly |
+| Mint | `mint` | Admin | ✅ enforced (`require_auth` + stored-admin equality) |
+| Transfer | `transfer` | User (`from`) | ✅ enforced (`from.require_auth()`) |
+| Read balance / supply | `balance`, `total_supply` | Anyone | — (view) |
+
+### `pausable_token.rs` — `PausableTokenContract`
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize | `initialize` | Admin (self-declared) | ✅ enforced, but **no re-init guard** |
+| Pause / Unpause | `pause`, `unpause` | Admin | ✅ enforced (`require_auth` + equality) |
+| Transfer | `transfer` | User (`from`) | ✅ enforced (`from.require_auth()`) |
+| Read paused state | `is_paused` | Anyone | — (view) |
+
+### `staking.rs` — `StakingContract`
+
+Correctly implemented alongside `soroban_token_contract.rs` and `pausable_token.rs`.
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize | `initialize` | — (bootstrap) | ❌ none (first caller becomes admin) |
+| Configure lock-up tier | `set_tier` | Admin | ✅ enforced (`admin.require_auth()`) |
+| Stake | `stake` | User | ✅ enforced (`user.require_auth()`) |
+| Withdraw | `withdraw` | User | ✅ enforced (`user.require_auth()`) |
+| View pending rewards | `pending_rewards` | Anyone | — (view) |
+
+### `circuit_breaker.rs` — `CircuitBreakerContract`
+
+The only "admin registry" contract with a correct `require_admin()`.
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize | `initialize` | — (bootstrap) | ❌ none (first caller becomes admin) |
+| Report price update | `check_price_update` | Keeper (oracle/feeder) | ❌ none |
+| Manual trip / reset | `manual_trip`, `reset` | Admin | ✅ enforced (`admin.require_auth()`) |
+| Update config | `update_config` | Admin | ✅ enforced |
+| Global pause | `set_global_pause` | Admin | ✅ enforced |
+| Force recovery | `force_recovery` | Admin | ✅ enforced |
+| Clear warning alerts | `clear_warning_alerts` | Admin | ✅ enforced |
+| Read status / history / health | `is_operational`, `get_status`, `get_trip_history`, `get_health_score`, etc. | Anyone | — (view) |
+
+### `liquidity_pool.rs` — `LiquidityPool` (on-chain contract)
+
+No admin concept — fully permissionless pool. The file also contains an unrelated,
+never-deployed simulation struct `LiquidityPoolContract` used in tests, whose "admin"
+setters have no auth at all (`⚠️` — see appendix).
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize pool | `initialize` | — (bootstrap) | ❌ none |
+| Add / remove liquidity | `add_liquidity`, `remove_liquidity` | User (`provider`) | ✅ enforced (`provider.require_auth()`) |
+| Swap | `swap`, `swap_a_for_b`, `swap_b_for_a` | User | ✅ enforced |
+| Claim fees | `claim_fees` | User (`provider`) | ✅ enforced |
+| Read position / fees | `get_position`, `get_collected_fees`, `get_liquidity_position` | Anyone | — (view) |
+
+### `lp_token_storage.rs` — `LpTokenStorage`
+
+No admin concept.
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Mint LP tokens | `mint` | Pool contract only | ❌ none — most severe finding in this file |
+| Burn LP tokens | `burn` | User (`from`) | ✅ enforced (`from.require_auth()`) |
+| Read balance / supply | `balance`, `total_supply` | Anyone | — (view) |
+
+### `stability_pool.rs` — `StabilityPoolContract`
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize | `initialize` | — (bootstrap) | ❌ none |
+| Deposit / withdraw / claim | `deposit`, `withdraw`, `claim_rewards` | User (`depositor`) | ❌ none |
+| Process liquidation credit | `process_liquidation` | Keeper (lending/vault contract) | ❌ none |
+| Update params, pause/unpause, update treasury | `update_params`, `pause`, `unpause`, `update_treasury` | Admin | ⚠️ broken (`require_admin` compares contract address, not caller) |
+| Read pool info / deposits / rewards | `get_user_deposit`, `get_pending_rewards`, `get_pool_info`, `get_params` | Anyone | — (view) |
+
+### `stablecoin.rs` — `StablecoinContract`
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize | `initialize` | — (bootstrap) | ❌ none |
+| Mint / redeem | `mint`, `redeem` | User (vault owner) | ❌ none |
+| Liquidate vault | `liquidate` | Keeper (liquidator) | ❌ none |
+| Stability pool deposit/withdraw | `deposit_stability_pool`, `withdraw_stability_pool` | User | ❌ none |
+| Add collateral type, pause/unpause, emergency shutdown, set fees | `add_collateral`, `pause`, `unpause`, `emergency_shutdown`, `set_minting_fee`, `set_redemption_fee` | Admin | ⚠️ broken |
+| Read supply / vault / ratio / pool info | `total_supply`, `get_vault`, `get_collateral_ratio`, `get_stability_pool_info`, `get_token_info` | Anyone | — (view) |
+
+### `vault.rs` — `YieldVaultContract`
+
+Plain Rust struct; imports `soroban_sdk` but never calls `require_auth`.
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize | `initialize` | — (bootstrap) | ❌ none, no re-init guard |
+| Add / switch / optimize strategy, collect fees, pause/unpause, emergency exit, set fee/treasury | `add_strategy`, `switch_strategy`, `optimize_strategy`, `collect_fees`, `pause`, `unpause`, `emergency_exit`, `set_performance_fee`, `set_treasury` | Admin | ⚠️ broken (`require_admin` only checks admin is *set*, not caller identity) |
+| Deposit / withdraw | `deposit`, `withdraw` | User (`depositor`/`withdrawer`) | ❌ none — compounded by no per-user share ledger (single aggregate `total_shares`) |
+| Harvest | `harvest` | Keeper | ❌ none (rate-limited by `MIN_HARVEST_INTERVAL`, not by auth) |
+| Read share price / info / stats | `get_share_price`, `get_info`, `get_stats`, `preview_deposit`, `preview_withdraw` | Anyone | — (view) |
+
+### `lending.rs` — `LendingProtocol`
+
+Plain Rust struct simulation (no Soroban auth primitives available). Multisig
+admin model via `MultiSigConfig { admins: Vec<String>, threshold }`.
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Deposit / withdraw / toggle collateral | `deposit`, `withdraw`, `set_collateral_enabled` | User | ❌ none (string-identified caller, no signature) |
+| Borrow / repay | `borrow`, `repay` | User | ❌ none |
+| Liquidate | `liquidate` | Keeper (liquidator) | ❌ none |
+| Flash loan | `flash_loan` | Keeper/User | ❌ none |
+| Pause / unpause, set rate models, caps, reserve factor | `pause`, `unpause`, `set_default_interest_rate_model`, `set_asset_interest_rate_model`, `set_supply_cap`, `set_borrow_cap`, `set_reserve_factor` | Admin | ⚠️ broken — calls `ensure_admin()`, which is **referenced but never defined** anywhere in the codebase |
+| Approve/execute/cancel multisig proposal | `approve_admin_proposal`, `execute_admin_proposal`, `cancel_admin_proposal` | Admin (multisig member) | ⚠️ logic present but **unreachable** — no `propose_*` function ever inserts into `proposals`, so nothing can reach quorum |
+| Register asset, update reserve config, set close factor, collect fees | `register_asset`, `update_reserve_config`, `set_close_factor`, `collect_protocol_fees` | Admin (single-sig fast-path) | ⚠️ gated by `threshold == 1`; with `threshold > 1` these are **permanently unreachable** (same proposal-flow gap) |
+| Read admins/treasury/paused/reserves/positions | `admins`, `threshold`, `treasury`, `is_paused`, `reserve_state`, `position`, `snapshot`, `events` | Anyone | — (view) |
+
+### `flash_loan.rs` — `FlashLoanContract`
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize | `initialize` | — (bootstrap) | ❌ none |
+| Flash loan / liquidate via flash loan | `flash_loan`, `liquidate_with_flash_loan` | Keeper/User | ❌ none (simulated transfers only) |
+| Set fee, pause, resume | `set_fee`, `pause`, `resume` | Admin | ⚠️ broken — `require_admin()` is a documented no-op (`// In production: env.invoker().require_auth();`) |
+| Read info / calculate fee | `get_info`, `calculate_fee`, `arbitrage_safeguard` | Anyone | — (view) |
+
+### `arbitrage.rs` — `ArbitrageContract`
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize | `initialize` | — (bootstrap) | ❌ none |
+| Detect opportunity | `detect_opportunity` | Keeper (bot/oracle) | ❌ none |
+| Execute arbitrage / report failure | `execute_arbitrage`, `report_failed_arbitrage` | Keeper/User (`arbitrageur`) | ❌ none |
+| Update params, pause/unpause | `update_params`, `pause`, `unpause` | Admin | ⚠️ broken |
+| Read opportunities / stats / params | `get_active_opportunities`, `get_arbitrageur_stats`, `get_system_stats`, `get_params` | Anyone | — (view) |
+
+### `oracle.rs` — `PriceOracle` (correct) and `PriceOracleSim` (internal sim)
+
+`PriceOracle` is the only oracle-family contract with a fully correct admin check.
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize | `initialize` | — (bootstrap) | ❌ none |
+| Set price | `set_price` (`PriceOracle`) | Admin | ✅ enforced (`caller.require_auth()` + equality) |
+| Set price / sanity config (`PriceOracleSim`, used internally by `lending.rs`) | `set_price`, `set_price_at`, `set_sanity_config` | Admin | ❌ none (string-equality only, no cryptographic auth exists in this struct) |
+| Read price(s) | `get_price`, `get_price_at`, `admin` | Anyone | — (view) |
+
+### `price_oracle.rs` — `PriceOracleContract`
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize | `initialize` | — (bootstrap) | ❌ none |
+| Update price | `update_price` | Keeper (registered source) | ❌ none — only checks address is *listed*, never authenticates it |
+| Add/remove source, update weight/threshold, reset/enable circuit breaker, pause/unpause | `add_price_source`, `remove_price_source`, `update_source_weight`, `set_price_update_threshold`, `reset_circuit_breaker`, `set_circuit_breaker_enabled`, `pause`, `unpause` | Admin | ⚠️ broken |
+| Read price / TWAP / sources / alerts | `get_price`, `get_twap`, `get_price_sources`, `get_deviation_alerts`, `is_operational` | Anyone | — (view) |
+
+### `decentralized_oracle.rs` — `DecentralizedOracle`
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize | `initialize` | — (bootstrap) | ❌ none |
+| Register oracle (stake) | `register_oracle` | Keeper (oracle operator) | ❌ none |
+| Submit price | `submit_price` | Keeper (registered oracle) | ❌ none |
+| Request unbond / withdraw stake | `request_unbond`, `withdraw_stake` | Keeper (self) | ❌ none — anyone can unbond/withdraw *any* oracle's stake to any timeline |
+| Slash oracle, update config, pause/unpause | `slash_oracle`, `update_config`, `pause`, `unpause` | Admin | ⚠️ broken, but at least compares the *passed-in* admin argument (not `require_auth`-backed) |
+| Read price / stake / reputation | `get_price`, `get_oracle_stake`, `get_oracle_reputation`, `get_oracle_addresses` | Anyone | — (view) |
+
+### `multi_asset_oracle.rs` — `MultiAssetOracleContract`
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize | `initialize` | — (bootstrap) | ❌ none |
+| Submit price | `submit_price` | Keeper | ❌ none |
+| Clear alerts, pause/unpause, update asset registry | `clear_deviation_alerts`, `pause`, `unpause`, `update_asset_registry` | Admin | ⚠️ broken |
+| Read price / TWAP / history / alerts | `get_price`, `get_twap_price`, `get_batch_prices`, `get_price_history`, `get_deviation_alerts` | Anyone | — (view) |
+
+### `oracle_manager.rs` — `OracleManagerContract`
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize | `initialize` | — (bootstrap) | ❌ none |
+| Submit price | `submit_price` | Keeper (registered oracle) | ❌ none |
+| Register/deactivate oracle, update weight/params | `register_oracle`, `deactivate_oracle`, `update_oracle_weight`, `update_aggregation_params` | Admin | ⚠️ broken |
+| Read aggregated price / oracle info / alerts | `get_aggregated_price`, `get_oracle_info`, `get_registered_oracles`, `get_price_alerts` | Anyone | — (view) |
+
+### `price_feed_adapters.rs` — `PriceFeedAdaptersContract`
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize | `initialize` | — (bootstrap) | ❌ none |
+| Register/activate/deactivate adapter, update settings/category config | `register_adapter`, `activate_adapter`, `deactivate_adapter`, `update_adapter_settings`, `update_category_config` | Admin | ⚠️ broken |
+| Read adapter/category config, validate price | `get_category_config`, `get_adapter_config`, `get_adapters_for_category`, `validate_price`, `get_recommended_aggregation`, `get_all_adapters`, `get_all_category_configs` | Anyone | — (view) |
+
+### `asset_registry.rs` — `AssetRegistryContract`
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize | `initialize` | — (bootstrap) | ❌ none |
+| Update price | `update_price` | Keeper (approved source) | ❌ none — no source-membership check at all, most severe gap in this file |
+| Register/update asset, price sources, whitelist, cross-chain mapping, activate/deactivate, pause/unpause | `register_asset`, `update_asset_metadata`, `update_price_config`, `add_price_source`, `remove_price_source`, `register_price_source`, `whitelist_asset`, `remove_from_whitelist`, `register_cross_chain_asset`, `activate_asset`, `deactivate_asset`, `pause`, `unpause` | Admin | ⚠️ broken |
+| Read asset / price / history / whitelist / stats | `get_asset`, `get_all_assets`, `get_assets_by_category`, `get_price`, `get_price_history`, `is_whitelisted`, `get_cross_chain_asset`, `get_asset_stats` | Anyone | — (view) |
+
+### `position_manager.rs` — `PositionManagerContract`
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize | `initialize` | — (bootstrap) | ❌ none |
+| Create monitored position, create batch op | `create_monitored_position`, `create_batch_operation` | Admin | ⚠️ broken |
+| Monitor positions, execute batch op, acknowledge alert | `monitor_positions`, `execute_batch_operation`, `acknowledge_alert` | Keeper | ❌ none — any caller can execute any user's pending batch or acknowledge any alert |
+| Rebalance position | `rebalance_position` | Admin | ⚠️ broken |
+| Read analytics / alerts | `get_position_analytics`, `get_user_alerts` | Anyone | — (view) |
+
+### `synthetic_protocol.rs` — `SyntheticProtocolContract`
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize | `initialize` | — (bootstrap) | ❌ none |
+| Mint / burn synthetic, stake / unstake | `mint_synthetic`, `burn_synthetic`, `stake`, `unstake` | User | ❌ none |
+| Liquidate position | `liquidate_position` | Keeper | ❌ none |
+| Update oracle price | `update_oracle_price` | Keeper (whitelisted oracle) | ❌ none — membership-only check, no auth |
+| List asset, pause/unpause, update risk params | `list_asset`, `pause`, `unpause`, `update_risk_params` | Admin | ⚠️ broken |
+| Read asset / position / price / stats | `get_asset`, `get_user_position`, `get_asset_price`, `get_protocol_stats`, `get_listed_assets` | Anyone | — (view) |
+
+### `governance.rs` — `GovernanceContract` (off-chain simulation struct)
+
+Not a deployed Soroban contract — no auth primitives exist in this file.
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Create proposal | `create_proposal` | Governance (proposer, token-gated) | ❌ none; voting-power gate is moot since `get_voting_power` always returns 0 |
+| Vote | `vote` | Governance (voter) | ❌ none; caller self-reports their own `voting_power` |
+| Execute proposal | `execute_proposal` | Keeper (permissionless executor) | ❌ none (by design — anyone may execute a passed proposal) |
+| Cancel proposal | `cancel_proposal` | Governance (original proposer) | ❌ none (checked by field equality only, not auth) |
+| Update governance parameters | `update_parameters` | Admin/Governance (intended: proposal-gated) | ❌ none — directly callable by anyone despite doc comment |
+| Delegate | `delegate` | Governance (delegator) | N/A — stub, no-op |
+| Read proposals / voting power / delegation | `get_proposal`, `get_all_proposals`, `get_active_proposals`, `has_proposal_passed`, `get_voting_power`, `get_delegation` | Anyone | — (view) |
+
+### `governance_v2.rs` — `GovernanceContractV2`
+
+Real voting-period / quorum / execution-delay timelock logic exists here, but bypassable via the admin fast-path.
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize | `initialize` | — (bootstrap) | ❌ none |
+| Create proposal | `create_proposal` | Governance (proposer ≥ threshold voting power) | ❌ none |
+| Vote | `vote` | Governance (voter) | ❌ none |
+| Execute proposal | `execute_proposal` | Keeper (permissionless, after quorum + delay) | ❌ none (by design) |
+| Delegate | `delegate` | Governance (delegator) | ❌ none |
+| Update params (voting period/quorum/threshold/delay) | `update_params` | Admin (documented as a temporary fast-path — *"should only be callable through a successful proposal"*) | ⚠️ broken |
+| Emergency pause / unpause | `emergency_pause`, `unpause` | Admin | ⚠️ broken |
+| Read proposal / params / voting power | `get_proposal`, `get_active_proposals`, `get_params`, `get_voting_power` | Anyone | — (view); `get_voting_power` is a hardcoded mock |
+
+### `synthetic_governance.rs` — `SyntheticGovernanceContract`
+
+| Action | Function | Role (designed) | Enforcement |
+|---|---|---|---|
+| Initialize | `initialize` | — (bootstrap) | ❌ none |
+| Create proposal | `create_proposal` | Governance (proposer) | ❌ none; voting power mocked to a constant |
+| Vote | `vote` | Governance (voter) | ❌ none; double-vote guard (`has_voted`) is a stub that always returns `false` |
+| Execute proposal | `execute_proposal` | Keeper (permissionless, after timelock) | ❌ none (by design) |
+| Delegate | `delegate` | Governance (delegator) | ❌ none — any caller can set delegation for an arbitrary address |
+| Create multisig requirement | `create_multisig_requirement` | Admin | ⚠️ broken; result isn't persisted |
+| Pause/unpause, update governance params, emergency pause | `pause`, `unpause`, `update_governance_params`, `emergency_pause` | Admin | ⚠️ broken |
+| Read proposal / voting power / params | `get_proposal`, `get_active_proposals`, `get_voting_power`, `get_governance_params` | Anyone | — (view) |
+
+---
+
+## Role Capability Rollups
+
+### Admin capabilities (across all contracts)
+
+Admin is the highest-privilege role in every contract. Where designed correctly, Admin
+can, per contract: pause/unpause operations, tune risk/fee/interest parameters, manage
+allow-lists (collateral types, price sources, adapters, oracles), trigger emergency
+actions (shutdown, force recovery, manual circuit-breaker trip), and sweep protocol
+fees. **As currently implemented, only `circuit_breaker.rs`, `staking.rs`,
+`pausable_token.rs`, and `soroban_token_contract.rs` enforce Admin actions with real
+`require_auth()` checks.** Every other contract's admin surface is either unauthenticated
+or protected by the broken `require_admin()` pattern (see appendix) — meaning Admin
+capability today is either non-functional or wide open, contract by contract.
+
+### Governance capabilities (across all contracts)
+
+Governance participants, in `governance.rs`, `governance_v2.rs`, and
+`synthetic_governance.rs`, can: create proposals (subject to a minimum voting-power
+threshold), vote for/against within a voting window, delegate voting power to another
+address, and — after quorum and any execution delay are satisfied — trigger proposal
+execution (open to any Keeper, by design). **None of the three governance contracts
+verify voter/proposer/delegator identity with `require_auth()`, and voting power itself
+is either mocked to a constant or a non-functional stub in all three** — so the
+governance layer does not yet provide real Sybil resistance or non-repudiation. Treat
+it as a UI/coordination layer only until these gaps are closed.
+
+### Keeper capabilities (across all contracts)
+
+Keepers are intentionally permissionless in most cases — anyone can: submit oracle
+price updates (`update_price`, `submit_price` across all oracle contracts), execute a
+passed governance proposal, liquidate an under-collateralized position (`lending.rs`,
+`stablecoin.rs`, `synthetic_protocol.rs`), process a stability-pool liquidation credit,
+harvest a vault strategy, detect/execute an arbitrage opportunity, and monitor/rebalance
+tracked positions. This openness is by design for most of these (permissionless
+liquidation and proposal execution are standard DeFi patterns), **but several oracle
+and lending "keeper" actions should be restricted to a registered/staked set (e.g.
+`decentralized_oracle.rs`'s registered oracles) and currently are not** — see the
+appendix for which ones need real membership checks, not just open access.
+
+### User capabilities (across all contracts)
+
+Users can, depending on the contract: transfer/approve/burn tokens, deposit/withdraw
+liquidity or collateral, borrow/repay debt, mint/redeem/burn synthetic assets and the
+protocol stablecoin, stake/unstake for rewards, and swap between pool assets.
+**With the exception of `pausable_token.rs`, `soroban_token_contract.rs`, and the
+on-chain `liquidity_pool.rs`, user-facing state-changing functions across this codebase
+do not call `require_auth()` on the acting address** — meaning, as written, one account
+can currently perform these actions on behalf of another by simply passing that
+account's address as a parameter. This is the single highest-impact class of finding
+in this audit pass and should be prioritized above any Admin/Governance fix.
+
+---
+
+## Appendix: Enforcement Gaps Found During This Audit
+
+This appendix exists so remediation work can be tracked against a concrete list. Full
+threat-model context lives in [`SECURITY_AUDIT_CHECKLIST.md`](SECURITY_AUDIT_CHECKLIST.md).
+
+1. **Broken `require_admin()` pattern** — `governance_v2.rs`, `arbitrage.rs`,
+   `stablecoin.rs`, `stability_pool.rs`, `price_oracle.rs`, `multi_asset_oracle.rs`,
+   `price_feed_adapters.rs`, `position_manager.rs`, `oracle_manager.rs`,
+   `synthetic_protocol.rs`, `synthetic_governance.rs`, `asset_registry.rs`, and
+   `vault.rs` all implement admin gating by comparing `env.current_contract_address()`
+   (or, in `vault.rs`, simply checking `admin.is_some()`) instead of calling
+   `admin.require_auth()`. Fix: store the admin `Address`, call
+   `admin.require_auth()`, then compare against the stored value.
+2. **Missing `require_auth()` on user-supplied identity parameters** — the large
+   majority of `deposit`/`withdraw`/`mint`/`burn`/`stake`/`vote`/`delegate`-style
+   functions across the codebase accept an `Address` parameter representing the acting
+   party but never authenticate it. Fix: call `.require_auth()` on that parameter
+   before mutating state.
+3. **`lp_token_storage.rs::mint`** has no auth check whatsoever — any caller can mint
+   unlimited LP tokens to any address. This should be restricted to the owning pool
+   contract.
+4. **`asset_registry.rs::update_price`** has no source-membership check at all (unlike
+   its sibling oracle contracts, which at least check list membership).
+5. **`lending.rs`** references `ensure_admin()`, which is never defined, and its
+   multisig proposal-approval flow has no corresponding `propose_*` entry point —
+   both are compile/runtime blockers, not just access-control gaps.
+6. **Governance voting power is mocked or stubbed** in `governance.rs`,
+   `governance_v2.rs`, and `synthetic_governance.rs` (constant values or
+   always-`false` double-vote guards), so quorum and Sybil-resistance guarantees do
+   not hold yet.
+7. **No admin rotation/transfer function exists in any contract.** Every admin address
+   is permanent once set at `initialize()`, and `initialize()` itself is callable by
+   anyone in most contracts (first caller wins). A two-step
+   `propose_admin`/`accept_admin` pattern plus a re-initialization guard is recommended
+   protocol-wide.
+8. **Duplicate method names in the same `impl` block** (e.g. `get_pool_info`,
+   `get_price_sources`, `get_protocol_stats`, `get_governance_params`,
+   `get_asset_stats`, `get_voting_power`, `get_params` each defined twice — once public,
+   once private, with the same name) in `stability_pool.rs`, `price_oracle.rs`,
+   `synthetic_protocol.rs`, `synthetic_governance.rs`, `asset_registry.rs`, and
+   `governance_v2.rs`. These are compile-time blockers independent of access control
+   and should be resolved (rename the private helper) before any of the above fixes
+   can be validated by `cargo build`.
+
+None of the above are fixed by this documentation change — they are recorded here and
+in the security checklist so they can be triaged and fixed as dedicated follow-up work,
+tracked function-by-function against this matrix.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,376 @@
+# Protocol Architecture
+
+This document is the protocol-wide architecture reference: how the contracts fit
+together, how the main user/keeper/governance flows move through them, the economic
+model that drives fees and interest, and the risk parameters that bound the system.
+
+Related documents:
+- [`ACCESS_CONTROL_MATRIX.md`](ACCESS_CONTROL_MATRIX.md) — who can call what, per contract.
+- [`SECURITY_AUDIT_CHECKLIST.md`](SECURITY_AUDIT_CHECKLIST.md) — threat model and audit checklist.
+- [`stablecoin_economic_model.md`](stablecoin_economic_model.md) — stablecoin-specific economic deep dive.
+- [`synthetic_protocol_risk_management.md`](synthetic_protocol_risk_management.md) — synthetic-asset-specific risk deep dive.
+- [`staking_contract.md`](staking_contract.md), [`circuit_breaker_guide.md`](circuit_breaker_guide.md), [`CIRCUIT_BREAKER_V2_README.md`](CIRCUIT_BREAKER_V2_README.md) — per-module guides.
+
+This document covers the protocol as a whole; it does not repeat what those documents
+already cover in depth.
+
+---
+
+## 1. Architecture Overview
+
+The toolkit is a collection of independent Soroban contracts (`src/contracts/`)
+sharing common types (`src/types/`) and fixed-point math utilities
+(`src/utils/fixed_point.rs`), exposed to off-chain consumers through a GraphQL API
+(`src/api/`) and a CLI (`src/main.rs`). Contracts group into five layers:
+
+1. **Oracle layer** — price discovery and validation, feeding every other layer.
+2. **Core protocol layer** — the money-handling contracts: lending, stablecoin,
+   synthetic assets, liquidity pools, yield vaults, staking.
+3. **Safety layer** — circuit breakers and the stability pool, which sit between the
+   oracle layer and the core protocols to absorb shocks.
+4. **Governance layer** — parameter and upgrade control over the other layers.
+5. **Interface layer** — the GraphQL API and CLI that expose protocol state and
+   actions to off-chain clients.
+
+```mermaid
+graph TB
+    subgraph Interface["Interface Layer"]
+        CLI["CLI (src/main.rs)"]
+        GQL["GraphQL API (src/api)"]
+    end
+
+    subgraph Governance["Governance Layer"]
+        GOV["governance.rs / governance_v2.rs"]
+        SYNGOV["synthetic_governance.rs"]
+    end
+
+    subgraph Core["Core Protocol Layer"]
+        LEND["lending.rs"]
+        STABLE["stablecoin.rs"]
+        SYN["synthetic_protocol.rs"]
+        LP["liquidity_pool.rs"]
+        VAULT["vault.rs"]
+        STAKE["staking.rs"]
+        ARB["arbitrage.rs"]
+        FLASH["flash_loan.rs"]
+    end
+
+    subgraph Safety["Safety Layer"]
+        CB["circuit_breaker.rs"]
+        SPOOL["stability_pool.rs"]
+        POSMGR["position_manager.rs"]
+    end
+
+    subgraph Oracle["Oracle Layer"]
+        ORACLE["oracle.rs"]
+        PORACLE["price_oracle.rs"]
+        DORACLE["decentralized_oracle.rs"]
+        MAORACLE["multi_asset_oracle.rs"]
+        OMGR["oracle_manager.rs"]
+        ADAPT["price_feed_adapters.rs"]
+        REG["asset_registry.rs"]
+    end
+
+    CLI --> LEND
+    GQL --> LEND
+    GQL --> STABLE
+    GQL --> SYN
+
+    GOV -- "parameter updates" --> STABLE
+    GOV -- "parameter updates" --> LEND
+    SYNGOV -- "asset listing / params" --> SYN
+
+    LEND -- "price reads" --> ORACLE
+    STABLE -- "price reads" --> PORACLE
+    SYN -- "price reads" --> OMGR
+    LP -- "oracle price divergence check" --> MAORACLE
+    ARB -- "price reads" --> PORACLE
+
+    STABLE -- "liquidation credit" --> SPOOL
+    LEND -- "liquidation" --> LEND
+    SYN -- "liquidation" --> SYN
+    SYN -- "position tracking" --> POSMGR
+
+    PORACLE --> CB
+    DORACLE --> CB
+    MAORACLE --> CB
+    OMGR --> CB
+
+    OMGR --> ADAPT
+    OMGR --> REG
+    MAORACLE --> REG
+
+    LEND -. "flash loans" .-> FLASH
+    VAULT -. "yield strategies" .-> LP
+    STAKE -. "reward accrual" .-> STAKE
+```
+
+**How to read this diagram:** solid arrows are direct read/write dependencies in the
+current code; dashed arrows are conceptual/intended integrations. As documented in
+[`ACCESS_CONTROL_MATRIX.md`](ACCESS_CONTROL_MATRIX.md), several of these
+cross-contract calls (e.g. `stability_pool.rs::process_liquidation`,
+`synthetic_protocol.rs::update_oracle_price`) are not yet gated to only accept calls
+from their intended caller contract — treat the diagram as the intended data flow,
+not a claim that every edge is access-controlled today.
+
+---
+
+## 2. Module Interaction Flows
+
+### 2.1 Stablecoin minting
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Stablecoin as stablecoin.rs
+    participant Oracle as price_oracle.rs
+    participant Vault as Vault storage
+
+    User->>Stablecoin: mint(to, collateral_token, collateral_amount, debt_amount)
+    Stablecoin->>Oracle: get_price(collateral_token)
+    Oracle-->>Stablecoin: price, confidence
+    Stablecoin->>Stablecoin: compute resulting collateral ratio
+    alt ratio >= collateral's min_collateral_ratio
+        Stablecoin->>Vault: record collateral + debt, deduct minting fee
+        Stablecoin-->>User: mint succeeds, SUSD debt increases
+    else ratio too low
+        Stablecoin-->>User: reject (insufficient collateral)
+    end
+```
+
+### 2.2 Liquidation (lending protocol)
+
+```mermaid
+sequenceDiagram
+    actor Keeper
+    participant Lending as lending.rs
+    participant Oracle as PriceOracleSim
+    participant StabilityPool as stability_pool.rs
+
+    Keeper->>Lending: liquidate(borrower, debt_asset, collateral_asset, repay_amount)
+    Lending->>Oracle: get_price(debt_asset), get_price(collateral_asset)
+    Oracle-->>Lending: prices
+    Lending->>Lending: compute health_factor
+    alt health_factor < WAD (undercollateralized)
+        Lending->>Lending: cap repay by close_factor_bps, seize collateral + bonus
+        Lending-->>Keeper: liquidation bonus (liquidation_bonus_bps)
+        Lending->>StabilityPool: process_liquidation(penalty_share)
+    else position healthy
+        Lending-->>Keeper: reject (not liquidatable)
+    end
+```
+
+### 2.3 Oracle aggregation and circuit breaker
+
+```mermaid
+sequenceDiagram
+    participant Source as Price source / Keeper
+    participant Oracle as price_oracle.rs / oracle_manager.rs
+    participant CB as circuit_breaker.rs
+    participant Consumer as Any price-consuming contract
+
+    Source->>Oracle: update_price(asset, price)
+    Oracle->>Oracle: check source is listed, weight, deviation vs. last price
+    Oracle->>CB: check_price_update(asset, old_price, new_price)
+    alt deviation within thresholds
+        CB-->>Oracle: Active (operational)
+        Oracle->>Oracle: write new aggregated price, update TWAP history
+    else deviation exceeds threshold (single or consecutive)
+        CB-->>Oracle: Tripped
+        Oracle-->>Source: price update rejected / recorded but flagged
+    end
+    Consumer->>Oracle: get_price(asset)
+    Oracle->>CB: is_operational(asset)?
+    alt operational
+        Oracle-->>Consumer: aggregated price
+    else tripped or in recovery
+        Oracle-->>Consumer: panic / reject (per is_operational contract)
+    end
+```
+
+### 2.4 Governance proposal lifecycle
+
+```mermaid
+sequenceDiagram
+    actor Proposer
+    actor Voter
+    actor Executor as Keeper (permissionless)
+    participant Gov as governance_v2.rs
+
+    Proposer->>Gov: create_proposal(proposal_type)
+    Gov->>Gov: check proposer voting power >= proposal_threshold_bps
+    Gov-->>Proposer: proposal created, voting_deadline set (3-30 days)
+    Voter->>Gov: vote(proposal_id, support)
+    Gov->>Gov: tally votes_for / votes_against
+    Note over Gov: after voting_deadline + execution_delay (2 days)
+    Executor->>Gov: execute_proposal(proposal_id)
+    Gov->>Gov: check quorum_bps met, votes_for > votes_against, delay elapsed
+    alt passes
+        Gov->>Gov: apply proposal effects, mark executed
+    else fails quorum or vote
+        Gov-->>Executor: reject
+    end
+```
+
+> As noted in [`SECURITY_AUDIT_CHECKLIST.md`](SECURITY_AUDIT_CHECKLIST.md#governance-attacks),
+> voting power in the current implementation is mocked/stubbed rather than derived
+> from real token balances — the flow above describes the intended design, which the
+> voting-power wiring has not yet caught up to.
+
+---
+
+## 3. Economic Model
+
+### 3.1 Fixed-point conventions
+
+All contracts share the fixed-point conventions in `src/utils/fixed_point.rs`:
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `WAD` | `1_000_000_000` (1e9) | Fixed-point unit for rates/ratios (e.g. `WAD` = 100% utilization) |
+| `BPS_DENOMINATOR` | `10_000` | Basis points denominator (e.g. `500` bps = 5%) |
+| `YEAR_IN_SECONDS` | `31_536_000` | Used to annualize per-second interest accrual |
+
+`mul_div(a, b, denom) = (a * b) / denom` (checked, returns `Result` on overflow) is
+the base primitive; `wad_mul`/`wad_div`/`bps_mul` are convenience wrappers over it.
+Prefer these over raw arithmetic — see the overflow guidance in
+[`SECURITY_AUDIT_CHECKLIST.md`](SECURITY_AUDIT_CHECKLIST.md#integer-overflow--underflow--precision-loss).
+
+### 3.2 Lending interest rate model (`lending.rs`, `types/lending.rs`)
+
+A standard two-slope, kinked utilization curve:
+
+```
+utilization = total_borrows / total_supply                     (WAD-scaled)
+
+if utilization <= optimal_utilization:
+    borrow_rate = base_rate + utilization * slope_1 / optimal_utilization
+
+else:
+    excess_utilization = utilization - optimal_utilization
+    excess_capacity    = WAD - optimal_utilization
+    borrow_rate = base_rate + slope_1
+                  + excess_utilization * slope_2 / excess_capacity
+```
+
+Default parameters (`InterestRateModel::default()`), all WAD-scaled:
+
+| Parameter | Value | As a rate |
+|---|---|---|
+| `base_rate` | `20_000_000` | 2% |
+| `slope_1` | `80_000_000` | 8% (rate added as utilization rises to optimal) |
+| `slope_2` | `1_200_000_000` | 120% (steep penalty slope above optimal utilization) |
+| `optimal_utilization` | `800_000_000` | 80% |
+
+**Rationale:** below 80% utilization, rates rise gently (2%→10%) to attract just
+enough borrowing demand. Above 80%, the slope steepens sharply (up to 130%+ at 100%
+utilization) to rapidly incentivize repayment/new deposits and protect withdrawal
+liquidity — the standard Aave/Compound-style kink. Per-asset overrides are supported
+via `set_asset_interest_rate_model`.
+
+Supply-side yield is the protocol's borrow interest minus the `reserve_factor_bps`
+protocol cut (`set_reserve_factor`, capped at 10,000 bps / 100%).
+
+### 3.3 Stablecoin economic model (`stablecoin.rs`)
+
+Fully detailed in [`stablecoin_economic_model.md`](stablecoin_economic_model.md).
+Summary of the core parameters:
+
+| Parameter | Value |
+|---|---|
+| Minimum collateral ratio | 110% |
+| Default collateral ratio | 150% |
+| Maximum collateral ratio | 500% |
+| Min / max debt per vault | 100 / 10,000 SUSD |
+| Minting / redemption fee | 0.5% / 0.5% (capped at 10% each by `set_minting_fee`/`set_redemption_fee`) |
+| Liquidation penalty | 10% |
+| Stability pool reward | ~5% APY (governance-tunable) |
+| Arbitrage reward | 0.5%–2%, sliding with deviation severity |
+
+### 3.4 Synthetic asset protocol (`synthetic_protocol.rs`)
+
+Risk-parameter deep dive in
+[`synthetic_protocol_risk_management.md`](synthetic_protocol_risk_management.md).
+Key mechanics: over-collateralized minting against a configurable
+`min_collateral_ratio`/`max_collateral_ratio` per asset, liquidation once
+`current_ratio < liquidation_threshold` (10% penalty, split 90/10 between liquidator
+and the position owner), and a minting fee capped at 10% by `update_risk_params`.
+Oracle confidence must be ≥ 80% (`8000`/`10000`) for any price-dependent action.
+
+### 3.5 Staking rewards (`staking.rs`)
+
+Fixed lock-up-duration tiers, each with its own APY, configured via `set_tier`:
+
+| Lock-up | Default APY |
+|---|---|
+| 0 days (flexible) | 2% |
+| 30 days | 5% |
+| 90 days | 10% |
+| 365 days | 25% |
+
+Rewards accrue linearly over elapsed time at the tier's APY and are paid out
+alongside principal on `withdraw`, which reverts if called before
+`start_time + lock_up_duration` has elapsed.
+
+### 3.6 Liquidity pool fees (`liquidity_pool.rs`)
+
+Constant-product AMM (`x * y = k`) with a 0.3% swap fee baked into
+`swap`/`swap_a_for_b`/`swap_b_for_a`, collected pro-rata to LP share on
+`claim_fees`. Slippage protection is caller-supplied (`min_out`/`in_max`).
+
+### 3.7 Flash loans and arbitrage
+
+`flash_loan.rs` charges a default fee of 9 bps (0.09%) on the borrowed amount
+(`set_fee`, capped at 1000 bps / 10%); `lending.rs::flash_loan` charges the
+per-asset `flash_loan_fee_bps` configured on that reserve. `arbitrage.rs` rewards
+detected/executed arbitrage on a sliding scale (0.5%–2%) proportional to deviation
+severity, bounded by `min_deviation_bps`/`max_deviation_bps` (default 10–500 bps).
+
+---
+
+## 4. Risk Parameters
+
+This section consolidates the risk-relevant configuration knobs across contracts.
+For the full rationale behind synthetic-asset and stablecoin parameters specifically,
+see the dedicated documents linked in Section 3.
+
+| Contract | Parameter | Default / Bound | Rationale |
+|---|---|---|---|
+| `lending.rs` | `supply_cap` / `borrow_cap` per asset | 0 = uncapped, admin-set | Bounds protocol exposure to any single asset; a cap of 0 is an explicit "no limit" choice, not an unset default. |
+| `lending.rs` | `close_factor_bps` | admin-set | Limits how much of a position can be liquidated in one call, preventing over-liquidation griefing. |
+| `lending.rs` | `reserve_factor_bps` | ≤ 10,000 bps | Protocol's cut of borrow interest; funds treasury/insurance without starving supplier yield. |
+| `stablecoin.rs` | `min_collateral_ratio` per collateral type | ≥ 110% | Floor below which a position is immediately liquidatable; set above 100% to absorb price-feed latency and liquidation slippage. |
+| `stablecoin.rs` | `max_collateral_ratio` per collateral type | ≤ 500% | Prevents pathological configuration that would make an asset unusable as collateral. |
+| `stablecoin.rs` | Minting/redemption fee | ≤ 1000 bps (10%) | Caps admin's ability to set punitive fees; revenue lever bounded for user protection. |
+| `synthetic_protocol.rs` | `min_collateral_ratio` (global floor via `update_risk_params`) | admin-set floor | Prevents governance/admin from setting protocol-wide ratios below a safe minimum. |
+| `synthetic_protocol.rs` | Oracle confidence floor | ≥ 8000/10000 (80%) | Rejects mint/burn/liquidation actions during periods of low oracle confidence. |
+| `circuit_breaker.rs` | Single-update deviation threshold | 1000 bps (10%) | Trips the breaker on a single large price jump — the classic oracle-manipulation signature. |
+| `circuit_breaker.rs` | Consecutive-deviation threshold | 3 updates > 5% | Catches slower manipulation/ramp attacks that stay under the single-update threshold. |
+| `decentralized_oracle.rs` | `MIN_STAKE` per oracle | admin-set | Raises the cost of registering a malicious oracle (Sybil resistance via bonding). |
+| `decentralized_oracle.rs` | `SLASH_PERCENTAGE` | 10% | Penalizes a misbehaving oracle's stake on `slash_oracle`. |
+| `decentralized_oracle.rs` | `UNBONDING_PERIOD` | 7 days | Delays stake withdrawal so slashing can still be applied to recently-misbehaving oracles. |
+| `governance_v2.rs` / `synthetic_governance.rs` | `voting_period` | 3–30 days (default 7) | Balances responsiveness against giving token holders enough time to notice and vote. |
+| `governance_v2.rs` / `synthetic_governance.rs` | `quorum_bps` | 5%–50% (default 10%) | Prevents low-turnout proposals from passing while remaining achievable. |
+| `governance_v2.rs` / `synthetic_governance.rs` | `execution_delay` | 2 days | Timelock giving users an exit window between a proposal passing and taking effect. |
+| `vault.rs` | `MAX_PERFORMANCE_FEE_BPS` | 30% | Caps the admin's yield-farming performance fee take. |
+| `vault.rs` | `MIN_HARVEST_INTERVAL` | 1 hour | Rate-limits harvest calls to bound gas/keeper-spam griefing. |
+| `asset_registry.rs` | `MAX_ASSETS`, `MAX_SOURCES_PER_ASSET` | 1000, 10 | Bounds unbounded storage growth (see DoS guidance in the security checklist). |
+
+**Important caveat:** several of the parameters above are only as strong as their
+enforcement. Where [`ACCESS_CONTROL_MATRIX.md`](ACCESS_CONTROL_MATRIX.md) flags a
+contract's admin check as broken, the corresponding risk parameters in that contract
+can currently be changed by anyone (or by no one, if the check always fails) rather
+than only by governance/admin as designed. Risk parameter design and access control
+enforcement are two independent concerns — this document covers the former; treat
+the latter as tracked separately.
+
+---
+
+## 5. Where This Fits With the Rest of the Docs
+
+| Document | Answers |
+|---|---|
+| This document | How are the contracts wired together, and what are the economic/risk parameters? |
+| [`ACCESS_CONTROL_MATRIX.md`](ACCESS_CONTROL_MATRIX.md) | Who can call which function, and is that actually enforced? |
+| [`SECURITY_AUDIT_CHECKLIST.md`](SECURITY_AUDIT_CHECKLIST.md) | What attack classes apply, and what's the current known-findings list? |
+| [`stablecoin_economic_model.md`](stablecoin_economic_model.md), [`synthetic_protocol_risk_management.md`](synthetic_protocol_risk_management.md), [`staking_contract.md`](staking_contract.md), [`circuit_breaker_guide.md`](circuit_breaker_guide.md) | Deep dives on a single module. |

--- a/docs/SECURITY_AUDIT_CHECKLIST.md
+++ b/docs/SECURITY_AUDIT_CHECKLIST.md
@@ -1,0 +1,308 @@
+# Security Audit Checklist & Threat Model
+
+This document is the protocol-wide threat model and pre-audit checklist for the
+Stellar DeFi Toolkit. It exists to (1) enumerate the attack surface across every
+contract, (2) give contributors and auditors a concrete checklist to run before
+shipping or reviewing fund-handling changes, and (3) track known findings until
+they're remediated.
+
+Companion document: [`ACCESS_CONTROL_MATRIX.md`](ACCESS_CONTROL_MATRIX.md) — the
+per-function permission reference this threat model draws its attack-surface
+inventory from. Vulnerability disclosure process: [`.github/SECURITY.md`](../.github/SECURITY.md).
+
+> **Status note:** an initial audit pass performed while writing this checklist found
+> that several of the threats below are not hypothetical — they are the *current*
+> state of specific contracts in this codebase. Each threat category below lists
+> concrete findings alongside the general guidance, so this checklist doubles as a
+> live punch list. See [Appendix A](#appendix-a-current-known-findings-by-severity)
+> for the consolidated, severity-ranked list.
+
+---
+
+## 1. Threat Model
+
+### 1.1 Assets at risk
+
+- User-deposited collateral (native/token balances held by `lending.rs`,
+  `stablecoin.rs`, `synthetic_protocol.rs`, `liquidity_pool.rs`, `vault.rs`)
+- Protocol-owned treasury / fee accumulations
+- Minted synthetic assets and the protocol stablecoin's peg
+- Oracle price integrity (every contract that reads a price depends on it)
+- Governance control of protocol parameters and upgrade paths
+- Staked oracle/keeper bonds (`decentralized_oracle.rs`)
+
+### 1.2 Attacker profiles
+
+| Attacker | Capability | Primary targets |
+|---|---|---|
+| Unprivileged external account | Can call any public contract function, hold funds, submit transactions | Any function missing `require_auth()` |
+| Malicious or compromised "admin" | Controls (or spoofs, where checks are broken) a stored admin address | Parameter tuning, pausing, fee sweeps, collateral whitelist |
+| Malicious oracle / price feeder | Registered or spoofable price source | Price manipulation → liquidations, undercollateralized minting |
+| Flash-loan-funded attacker | Large, transient capital within a single transaction | Oracle manipulation, governance vote manipulation, liquidation sniping |
+| Governance attacker | Accumulates or borrows voting power | Malicious parameter/upgrade proposals |
+| MEV searcher / front-runner | Observes mempool, reorders transactions | `initialize()` front-running, liquidation sniping, sandwich attacks on swaps |
+
+### 1.3 Attack surfaces, by category
+
+#### Reentrancy
+
+Soroban's host-enforced call model reduces classic EVM-style reentrancy risk, but
+logical reentrancy (state read before an external call, written after) is still
+possible wherever a contract calls another contract or token mid-function.
+
+- **Where to look:** `flash_loan.rs` (has an explicit `Executing` reentrancy-guard flag
+  — verify it's checked/set/cleared correctly on every path, including error paths),
+  `vault.rs::harvest`/`switch_strategy` (external strategy calls), `lending.rs::liquidate`
+  and `::flash_loan` (state mutated around simulated external calls), any function that
+  calls into `stability_pool.rs` from another contract (e.g. `process_liquidation`).
+- **Checklist:**
+  - [ ] External calls (token transfers, cross-contract calls, strategy calls) happen
+        **after** all local state mutations (checks-effects-interactions).
+  - [ ] Reentrancy guard flags are set before the external call and cleared in all
+        exit paths, including panics/early returns.
+  - [ ] No function relies on `total_supply`/balance snapshots taken before an
+        external call that could change them.
+
+#### Integer overflow / underflow / precision loss
+
+- **Where to look:** fee/interest calculations using `bps_mul`/`mul_div`/`wad_div`
+  (`lending.rs`, `utils/`), reward-index accumulation (`stability_pool.rs`,
+  `staking.rs`), collateral-ratio math (`stablecoin.rs`, `synthetic_protocol.rs`).
+  `token.rs::mint`/`burn` already check `u64` overflow/underflow and return `Err`
+  rather than panicking or wrapping — use that as the reference pattern.
+- **Checklist:**
+  - [ ] All arithmetic on user-supplied amounts uses checked/saturating operations,
+        not raw `+`/`-`/`*`.
+  - [ ] Division happens after multiplication (not before) to preserve precision,
+        and rounding direction favors the protocol, not the caller, in
+        fee/interest/collateral-ratio math.
+  - [ ] Basis-point (`bps`) and WAD-scaled (`1e18`/fixed-point) values are validated
+        against their expected ranges before use (e.g. fee bps ≤ 10,000).
+
+#### Oracle manipulation
+
+The most common real-world DeFi exploit vector, and the area with the most findings
+in this codebase.
+
+- **Where to look:** every contract in the oracle family (`oracle.rs`,
+  `price_oracle.rs`, `decentralized_oracle.rs`, `multi_asset_oracle.rs`,
+  `oracle_manager.rs`, `price_feed_adapters.rs`, `asset_registry.rs`) and every
+  consumer of their prices (`lending.rs`, `stablecoin.rs`, `synthetic_protocol.rs`,
+  `arbitrage.rs`).
+- **Checklist:**
+  - [ ] Price-submitting functions authenticate the caller as a genuinely registered
+        source (`require_auth()` + membership check — **not membership check alone**).
+  - [ ] Aggregation requires a minimum number of independent, weighted sources rather
+        than trusting a single feed.
+  - [ ] Staleness checks (`get_price_at`-style) are enforced on every consumer path,
+        not just available as an opt-in.
+  - [ ] Circuit breakers trip on both single-update and cumulative/consecutive
+        deviation, and consumers actually check `is_operational`/breaker status before
+        acting on a price.
+  - [ ] TWAP or multi-block price averaging is used wherever a single-block spot price
+        could be manipulated within one flash-loan-funded transaction.
+- **Current findings:** `price_oracle.rs::update_price`,
+  `oracle_manager.rs::submit_price`, `decentralized_oracle.rs::submit_price`,
+  `multi_asset_oracle.rs::submit_price`, and `asset_registry.rs::update_price` all
+  accept a source/oracle address as a parameter without calling `require_auth()` on
+  it — `price_oracle.rs` and `oracle_manager.rs` at least check list membership, but
+  `asset_registry.rs::update_price` has **no check of any kind**. Any caller can
+  currently submit an arbitrary price under any address's name.
+
+#### Flash loan attacks
+
+- **Where to look:** `flash_loan.rs`, `lending.rs::flash_loan`, any function that
+  reads a spot price or a total-supply/reserve snapshot without TWAP protection
+  (compounds with the oracle-manipulation category above).
+- **Checklist:**
+  - [ ] Flash-loan fee/repayment verification happens against actual post-callback
+        balances, not a value cached before the callback.
+  - [ ] No privileged action (governance vote, liquidation eligibility, collateral
+        ratio check) can be satisfied using capital that exists only within the
+        attacker's own transaction.
+  - [ ] Flash-loan-fundable functions are identified and paired with a TWAP or
+        multi-block requirement wherever they gate on price or balance.
+- **Current findings:** `flash_loan.rs` simulates transfers via `log!` rather than
+  performing real token movement, so its repayment check is not yet a meaningful
+  guard against real capital; treat this as unimplemented, not as a passing check,
+  until real token transfers are wired in.
+
+#### Governance attacks
+
+- **Where to look:** `governance.rs`, `governance_v2.rs`, `synthetic_governance.rs`.
+- **Checklist:**
+  - [ ] Voting power is derived from an actual, non-spoofable token balance/snapshot
+        — never self-reported by the caller or hardcoded.
+  - [ ] Proposal execution requires quorum computed against a real total-supply
+        figure, not a mocked constant.
+  - [ ] A timelock/execution delay separates a passing vote from its execution,
+        giving users an exit window.
+  - [ ] Emergency/admin fast-paths that bypass the proposal flow are minimized,
+        time-boxed, and clearly flagged as temporary (see `governance_v2.rs`'s
+        `update_params` comment, which already self-identifies this issue).
+  - [ ] Double-voting and delegation-hijacking are actually prevented in storage, not
+        just in a stubbed helper function.
+- **Current findings:** all three governance contracts either mock voting power to a
+  constant (`governance_v2.rs`, `synthetic_governance.rs`) or always return `0`
+  (`governance.rs`), and `synthetic_governance.rs`'s double-vote guard
+  (`has_voted`) always returns `false`. Until real token-balance-based voting power
+  is wired in, none of these contracts provide real Sybil resistance or quorum
+  guarantees — treat the voting layer as advisory/off-chain-coordinated only.
+
+#### Access control (see full detail in the matrix)
+
+- **Checklist:**
+  - [ ] Every privileged function calls `require_auth()` on the identity it checks
+        against — comparing addresses without `require_auth()` is not authentication.
+  - [ ] `require_admin()`-style helpers compare the **caller's authenticated
+        address**, never `env.current_contract_address()`.
+  - [ ] `initialize()` either restricts who may call it (e.g. a deploy-time
+        constructor argument) or is treated as front-runnable and documented as such.
+  - [ ] Re-initialization is guarded (`has(&ADMIN)`-style checks) on every contract
+        that stores privileged state.
+  - [ ] An admin rotation path exists, or the single-admin-forever model is an
+        explicit, documented risk acceptance.
+- **Current findings:** see [`ACCESS_CONTROL_MATRIX.md`](ACCESS_CONTROL_MATRIX.md#appendix-enforcement-gaps-found-during-this-audit)
+  for the full, function-by-function list — this is the single largest category of
+  findings in the codebase today.
+
+#### Denial of service / griefing
+
+- **Where to look:** unbounded loops over user-controlled collections (`Vec`/`Map`
+  iteration in `get_all_assets`, `get_active_proposals`, alert lists), storage growth
+  (price history, event logs, alert lists — check they're capped, as
+  `circuit_breaker.rs` and `price_oracle.rs` already attempt via fixed retention
+  windows).
+- **Checklist:**
+  - [ ] Any loop over a collection has a bounded size (either a hard cap enforced at
+        insertion, like `MAX_ASSETS`/`MAX_ORACLES`, or pagination).
+  - [ ] No function can be permanently bricked by a single malicious input (e.g. an
+        unbounded `Vec` insert with no cap).
+
+#### Front-running / MEV
+
+- **Checklist:**
+  - [ ] `initialize()` calls that set an admin/critical config are deployed and
+        initialized atomically (e.g. in the same transaction as contract creation),
+        not left open as a separate, raceable call.
+  - [ ] Swap functions enforce caller-supplied slippage bounds (`min_out`/`max_in`) —
+        already present in `liquidity_pool.rs`, verify on any new swap path.
+  - [ ] Liquidation rewards don't create a winner-take-all race that centralizes
+        keeper participation (consider partial-fill or auction mechanisms for
+        high-value liquidations).
+
+---
+
+## 2. Pre-Audit Self-Assessment Template
+
+Copy this into your PR description (or a tracking issue) for any change that touches
+fund custody, price data, or privileged parameters:
+
+```markdown
+### Security Self-Assessment
+
+**What changed:** <brief description>
+
+**Attack surface touched:**
+- [ ] New or modified external call (token transfer, cross-contract call)
+- [ ] New or modified privileged (Admin/Governance) function
+- [ ] New or modified price-consuming or price-reporting logic
+- [ ] New or modified arithmetic on user-supplied amounts
+- [ ] New or modified loop over a user-growable collection
+
+**Checklist categories reviewed (check all that apply, per section 1.3 above):**
+- [ ] Reentrancy
+- [ ] Integer overflow/underflow/precision
+- [ ] Oracle manipulation
+- [ ] Flash loan attacks
+- [ ] Governance attacks
+- [ ] Access control (cross-check `docs/ACCESS_CONTROL_MATRIX.md`)
+- [ ] Denial of service / griefing
+- [ ] Front-running / MEV
+
+**New external dependencies or trust assumptions introduced:** <none, or describe>
+
+**Known residual risk (if any) and why it's acceptable to ship:** <describe, or N/A>
+```
+
+---
+
+## 3. Mitigation Strategy Reference
+
+| Threat | Primary mitigation | Secondary mitigation |
+|---|---|---|
+| Reentrancy | Checks-effects-interactions ordering | Explicit reentrancy guard flag (see `flash_loan.rs::Executing`) |
+| Overflow/underflow | Checked arithmetic, `Result`-returning math (see `token.rs::mint`/`burn`) | Fuzz/property tests on arithmetic helpers |
+| Oracle manipulation | `require_auth()`-backed source registration + multi-source weighted aggregation | TWAP, circuit breakers, staleness checks |
+| Flash loan attacks | TWAP/multi-block price and balance checks for privileged actions | Real (non-simulated) same-transaction repayment verification |
+| Governance attacks | Real token-balance-based voting power + timelock + quorum | Minimize/time-box admin fast-paths; require multisig for emergency actions |
+| Access control gaps | `require_auth()` on every identity parameter; correct `require_admin()` pattern | Two-step admin rotation, re-initialization guards |
+| DoS / griefing | Bounded collections, capped retention windows | Pagination for read paths over large collections |
+| Front-running / MEV | Atomic init-at-deploy, slippage bounds | Commit-reveal or batch auction for sensitive actions where relevant |
+
+---
+
+## 4. Review Cadence
+
+- **Quarterly:** full pass over this checklist and the access control matrix against
+  the current `main` branch; update Appendix A with newly found/newly fixed items.
+  Next review due: **2026-10-28** (quarter after this document's creation).
+- **Per-release:** any release that touches a contract in
+  `docs/ACCESS_CONTROL_MATRIX.md`'s "broken"/"none" enforcement rows must either fix
+  the gap or explicitly carry it forward in release notes as a known issue.
+- **Per-PR:** the self-assessment template in Section 2 for any fund-handling,
+  price-handling, or privileged-parameter change.
+- **Ad hoc:** immediately after any incident, near-miss, or externally reported
+  vulnerability (see [`.github/SECURITY.md`](../.github/SECURITY.md) for the
+  disclosure process) — do not wait for the next quarterly cycle.
+
+---
+
+## Appendix A: Current Known Findings (by severity)
+
+This list is generated from the initial audit pass performed alongside this
+checklist (2026-07-28) and should be updated as items are fixed or new ones found.
+Full per-function detail lives in
+[`ACCESS_CONTROL_MATRIX.md`](ACCESS_CONTROL_MATRIX.md#appendix-enforcement-gaps-found-during-this-audit).
+
+**Critical**
+
+1. Broken `require_admin()` pattern (compares contract address, not caller) across
+   12+ contracts — every "Admin only" function in those contracts is effectively
+   unauthenticated or permanently unreachable.
+2. Missing `require_auth()` on user-identity parameters across nearly all
+   fund-moving functions (`deposit`, `withdraw`, `mint`, `redeem`, `stake`, `vote`,
+   `delegate`, etc.) — any account can act on behalf of any other account.
+3. `lp_token_storage.rs::mint` has no auth check — unlimited free LP token minting.
+4. `asset_registry.rs::update_price` has no auth or membership check — anyone can
+   set an arbitrary asset price.
+5. `lending.rs` references an undefined `ensure_admin()` function and has an
+   unreachable multisig-proposal flow (no `propose_*` entry point) — compile/runtime
+   blockers layered on top of the access-control gap.
+
+**High**
+
+6. Governance voting power is mocked/stubbed in all three governance contracts —
+   no real quorum or Sybil resistance yet.
+7. `vault.rs` has no per-user share ledger — `withdraw` only checks the global
+   share total, not the caller's actual holdings.
+8. `flash_loan.rs` simulates transfers rather than moving real tokens, so its
+   repayment check is not a meaningful safety guard yet.
+9. Duplicate method names within the same `impl` block in 6 files
+   (`stability_pool.rs`, `price_oracle.rs`, `synthetic_protocol.rs`,
+   `synthetic_governance.rs`, `asset_registry.rs`, `governance_v2.rs`) — compile
+   blockers that must be resolved before any of the above fixes can be validated.
+
+**Medium**
+
+10. No admin rotation/transfer function exists in any contract — a single
+    permanently-fixed admin per contract, set by whoever calls `initialize()` first.
+11. `soroban_token_contract.rs` and `pausable_token.rs` have no re-initialization
+    guard on `initialize()`, despite otherwise-correct auth.
+12. Several "keeper" functions intended for a registered/staked set
+    (`decentralized_oracle.rs`'s oracle operations) are fully open instead of
+    membership-gated.
+
+None of these are fixed by the documentation changes in this PR — they are recorded
+here, and in the access control matrix, specifically so they can be triaged and
+scheduled as dedicated follow-up work rather than lost.

--- a/src/contracts/arbitrage.rs
+++ b/src/contracts/arbitrage.rs
@@ -10,6 +10,14 @@
 //! - Sliding scale rewards based on deviation severity
 //! - Anti-manipulation mechanisms
 //! - Performance tracking for arbitrageurs
+//!
+//! ## Access Control
+//! - **Admin**: `update_params`, `pause`, `unpause` — gated by `require_admin()`, which
+//!   is currently broken (compares the contract's own address, not the caller). See
+//!   `docs/ACCESS_CONTROL_MATRIX.md`.
+//! - **Keeper**: `detect_opportunity` (intended for bots/oracles), `execute_arbitrage`,
+//!   `report_failed_arbitrage` — open to any caller, no auth check on the acting address.
+//! - **User**: none beyond acting as a Keeper (any address may execute an opportunity).
 
 use crate::types::stablecoin::{AlertSeverity, ArbitrageOpportunity, OraclePrice, SystemStats};
 use soroban_sdk::{

--- a/src/contracts/asset_registry.rs
+++ b/src/contracts/asset_registry.rs
@@ -3,6 +3,16 @@
 //! Manages registration and configuration of a wide range of Stellar assets
 //! for price feed support. This contract serves as a central registry for
 //! asset metadata, price feed configurations, and asset whitelisting.
+//!
+//! ## Access Control
+//! - **Admin**: `register_asset`, `update_asset_metadata`, `update_price_config`,
+//!   `add_price_source`, `remove_price_source`, `register_price_source`,
+//!   `whitelist_asset`, `remove_from_whitelist`, `register_cross_chain_asset`,
+//!   `activate_asset`, `deactivate_asset`, `pause`, `unpause` — gated by a broken
+//!   `require_admin()` (see `docs/ACCESS_CONTROL_MATRIX.md`).
+//! - **Keeper**: `update_price` — intended for an approved price source, but has
+//!   **no membership or auth check at all**, the most severe gap in this file.
+//! - **User**: read-only (asset/price/whitelist lookups).
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec, Map, unwrap::UnwrapOptimized};
 use crate::types::asset::{

--- a/src/contracts/circuit_breaker.rs
+++ b/src/contracts/circuit_breaker.rs
@@ -10,6 +10,15 @@
 //! - Per-asset circuit breaker status
 //! - Rate limiting on price updates
 //! - Cascading protection across dependent contracts
+//!
+//! ## Access Control
+//! One of the few contracts in this codebase with fully correct enforcement — see
+//! `docs/ACCESS_CONTROL_MATRIX.md`.
+//! - **Admin**: `manual_trip`, `reset`, `update_config`, `set_global_pause`,
+//!   `force_recovery`, `clear_warning_alerts` — enforced via `admin.require_auth()`.
+//! - **Keeper**: `check_price_update` — intended for an oracle/feeder, but has no
+//!   auth check.
+//! - **User**: read-only (status/history/health-score lookups).
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Map, Vec};
 

--- a/src/contracts/decentralized_oracle.rs
+++ b/src/contracts/decentralized_oracle.rs
@@ -11,6 +11,16 @@
 //! - Governance through token holders
 //! - Price deviation detection and alerts
 //! - Circuit breaker for extreme price movements
+//!
+//! ## Access Control
+//! - **Admin**: `slash_oracle`, `update_config`, `pause`, `unpause` — `require_admin()`
+//!   compares the passed-in admin argument to the stored admin, but never calls
+//!   `require_auth()`, so it is not cryptographically enforced. See
+//!   `docs/ACCESS_CONTROL_MATRIX.md`.
+//! - **Keeper**: `register_oracle`, `submit_price`, `request_unbond`, `withdraw_stake` —
+//!   no auth check on the `oracle_address` parameter; any caller can act on behalf of
+//!   any registered oracle.
+//! - **User**: read-only (price/stake/reputation lookups).
 
 use soroban_sdk::{contract, contractimpl, contracterror, Address, Env, Symbol, Vec, Map, unwrap::UnwrapOptimized, symbol_short, panic_with_error};
 

--- a/src/contracts/flash_loan.rs
+++ b/src/contracts/flash_loan.rs
@@ -2,6 +2,13 @@
 //!
 //! Provides flash loan functionality allowing users to borrow assets
 //! without collateral as long as they are returned within the same transaction.
+//!
+//! ## Access Control
+//! - **Admin**: `set_fee`, `pause`, `resume` — `require_admin()` is a documented no-op
+//!   (`// In production: env.invoker().require_auth();`), so these are callable by
+//!   anyone once an admin has been configured. See `docs/ACCESS_CONTROL_MATRIX.md`.
+//! - **Keeper/User**: `flash_loan`, `liquidate_with_flash_loan` — open to any caller
+//!   (loans/transfers are simulated, not real token movements).
 
 use soroban_sdk::{contract, contractimpl, contracttype, contracterror, Address, Env, Symbol, Bytes, log};
 use crate::types::flash_loan::{FlashLoanInfo, LoanTakenEvent, LoanRepaidEvent, LiquidationParams};

--- a/src/contracts/governance.rs
+++ b/src/contracts/governance.rs
@@ -2,6 +2,16 @@
 //! 
 //! Provides decentralized governance functionality for protocol
 //! management and decision-making on the Stellar blockchain.
+//!
+//! ## Access Control
+//! This is a plain Rust simulation struct (no Soroban `require_auth` capability exists
+//! in this file). See `docs/ACCESS_CONTROL_MATRIX.md` for the full breakdown.
+//! - **Governance**: `create_proposal`, `vote`, `cancel_proposal`, `delegate` — caller
+//!   identity is a trusted `&str`/`Address` field, never authenticated; `vote` also lets
+//!   the caller self-report their own voting power.
+//! - **Keeper**: `execute_proposal` — permissionless by design.
+//! - **Admin**: `update_parameters` — doc comment says it should be proposal-gated, but
+//!   the code enforces no such restriction.
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
 use std::collections::HashMap;

--- a/src/contracts/governance_v2.rs
+++ b/src/contracts/governance_v2.rs
@@ -10,6 +10,18 @@
 //! - Quadratic voting support
 //! - Emergency governance actions
 //! - Delegation of voting power
+//!
+//! ## Access Control
+//! - **Admin**: `update_params`, `emergency_pause`, `unpause` — a documented temporary
+//!   fast-path ("should only be callable through a successful proposal... For now,
+//!   we'll require admin for testing"), gated by a broken `require_admin()` that
+//!   compares the contract's own address rather than the caller. See
+//!   `docs/ACCESS_CONTROL_MATRIX.md`.
+//! - **Governance**: `create_proposal`, `vote`, `delegate` — no `require_auth()` on the
+//!   proposer/voter/delegator address; `get_voting_power` is a hardcoded mock.
+//! - **Keeper**: `execute_proposal` — permissionless by design, after quorum + the
+//!   2-day execution delay.
+//! - **User**: read-only (proposal/params/voting-power lookups).
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec, Map, unwrap::UnwrapOptimized};
 use crate::types::stablecoin::{

--- a/src/contracts/lending.rs
+++ b/src/contracts/lending.rs
@@ -21,6 +21,22 @@ use crate::utils::{bps_mul, mul_div, wad_div, WAD, YEAR_IN_SECONDS};
 ///   emergency.
 /// - **Event log**: every state-changing action appends a `ProtocolEvent` to
 ///   `events`.  Callers can drain the log with `drain_events()`.
+///
+/// # Access Control
+/// This is a plain Rust struct simulation — no Soroban `require_auth` capability
+/// exists in this module. See `docs/ACCESS_CONTROL_MATRIX.md` for the full breakdown.
+/// - **Admin** (multisig `admins`/`threshold`): `pause`, `unpause`,
+///   `set_default_interest_rate_model`, `set_asset_interest_rate_model`,
+///   `set_supply_cap`, `set_borrow_cap`, `set_reserve_factor` call `ensure_admin()`,
+///   which is referenced but **never defined** anywhere in this codebase — a compile
+///   blocker, not just an access-control gap. `register_asset`,
+///   `update_reserve_config`, `set_close_factor`, `collect_protocol_fees` are gated
+///   by `threshold == 1`; with a multisig `threshold > 1` they route through
+///   `approve_admin_proposal`/`execute_admin_proposal`, but no `propose_*` function
+///   ever inserts into `proposals`, so that path is currently unreachable.
+/// - **Keeper**: `liquidate`, `flash_loan` — permissionless by design, no auth check.
+/// - **User**: `deposit`, `withdraw`, `borrow`, `repay`, `set_collateral_enabled` —
+///   caller identity is an unauthenticated `&str` parameter.
 #[derive(Debug, Clone)]
 pub struct LendingProtocol {
     multisig: MultiSigConfig,

--- a/src/contracts/liquidity_pool.rs
+++ b/src/contracts/liquidity_pool.rs
@@ -2,6 +2,15 @@
 //!
 //! Provides automated market maker (AMM) functionality for creating
 //! liquidity pools between different tokens on the Stellar blockchain.
+//!
+//! ## Access Control
+//! The on-chain `LiquidityPool` contract has no admin/governance concept — it is
+//! fully permissionless by design. **User**: `add_liquidity`, `remove_liquidity`,
+//! `swap`, `swap_a_for_b`, `swap_b_for_a`, `claim_fees` all correctly call
+//! `require_auth()` on the acting `provider`/`user` address. All other functions are
+//! read-only. This file also contains a separate, never-deployed simulation struct
+//! (`LiquidityPoolContract`) used only in tests, whose admin/emergency-mode setters
+//! have no auth checks — see `docs/ACCESS_CONTROL_MATRIX.md`.
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec, Map};
 use crate::types::pool::{PoolInfo, LiquidityPosition, SwapParams};

--- a/src/contracts/lp_token_storage.rs
+++ b/src/contracts/lp_token_storage.rs
@@ -1,4 +1,11 @@
 //! LP token storage tracking user balances in the liquidity pool (issue #23)
+//!
+//! ## Access Control
+//! - **`mint`** has **no auth check at all** — any caller can mint unlimited LP
+//!   tokens to any address. This should be restricted to the owning pool contract.
+//!   See `docs/ACCESS_CONTROL_MATRIX.md`.
+//! - **User**: `burn` — enforced via `from.require_auth()`.
+//! - **User**: read-only (`balance`, `total_supply`).
 
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
 

--- a/src/contracts/multi_asset_oracle.rs
+++ b/src/contracts/multi_asset_oracle.rs
@@ -2,6 +2,13 @@
 //!
 //! Enhanced price oracle that supports a wide range of Stellar assets
 //! with type-specific configurations and price feed routing.
+//!
+//! ## Access Control
+//! - **Admin**: `clear_deviation_alerts`, `pause`, `unpause`, `update_asset_registry` —
+//!   gated by a broken `require_admin()` (compares the contract's own address, not the
+//!   caller). See `docs/ACCESS_CONTROL_MATRIX.md`.
+//! - **Keeper**: `submit_price` — no auth check on the reporting address.
+//! - **User**: read-only (price/TWAP/history/alert lookups).
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec, Map, unwrap::UnwrapOptimized};
 use crate::types::asset::{

--- a/src/contracts/oracle.rs
+++ b/src/contracts/oracle.rs
@@ -3,6 +3,16 @@
 //! Provides two implementations:
 //! 1. `PriceOracle`: A proper, production-ready Soroban smart contract using `#[contract]` and `#[contractimpl]`.
 //! 2. `PriceOracleSim`: A simulated, standard Rust version of the price oracle for backward compatibility.
+//!
+//! ## Access Control
+//! - **`PriceOracle`** (Soroban contract): `set_price` is correctly gated — **Admin**
+//!   only, enforced via `caller.require_auth()` plus a stored-admin equality check.
+//!   This is one of the few functions in the whole codebase with fully correct
+//!   enforcement; see `docs/ACCESS_CONTROL_MATRIX.md`.
+//! - **`PriceOracleSim`** (internal simulation, used by `lending.rs`): `set_price`,
+//!   `set_price_at`, `set_sanity_config` are gated by plain `String` equality against
+//!   the stored admin — no cryptographic auth exists in this struct.
+//! - **User**: read-only (`get_price`, `get_price_at`, `admin`).
 
 use std::collections::BTreeMap;
 use soroban_sdk::{contract, contractimpl, contracterror, Address, Env, Map, String as SorobanString, Symbol};

--- a/src/contracts/oracle_manager.rs
+++ b/src/contracts/oracle_manager.rs
@@ -9,6 +9,14 @@
 //! - Oracle reputation system
 //! - Price deviation detection
 //! - Automatic oracle failover
+//!
+//! ## Access Control
+//! - **Admin**: `register_oracle`, `deactivate_oracle`, `update_oracle_weight`,
+//!   `update_aggregation_params` — gated by a broken `require_admin()` (compares the
+//!   contract's own address, not the caller). See `docs/ACCESS_CONTROL_MATRIX.md`.
+//! - **Keeper**: `submit_price` — intended for a registered oracle, but has no
+//!   `require_auth()` on the `oracle_address` parameter.
+//! - **User**: read-only (aggregated price/oracle info/alert lookups).
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec, Map, unwrap::UnwrapOptimized};
 use crate::types::synthetic::{OraclePrice, SyntheticAsset};

--- a/src/contracts/pausable_token.rs
+++ b/src/contracts/pausable_token.rs
@@ -1,4 +1,13 @@
 //! Pausable transfer mechanism for emergency token lockdown (issue #22)
+//!
+//! ## Access Control
+//! One of the few contracts in this codebase with fully correct enforcement — see
+//! `docs/ACCESS_CONTROL_MATRIX.md`.
+//! - **Admin**: `pause`, `unpause` — enforced via `require_auth()` plus a stored-admin
+//!   equality check.
+//! - **User**: `transfer` — enforced via `from.require_auth()`.
+//! - Caveat: `initialize` has no re-initialization guard, so it can be called more
+//!   than once to reset the admin/paused state.
 
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
 

--- a/src/contracts/position_manager.rs
+++ b/src/contracts/position_manager.rs
@@ -10,6 +10,15 @@
 //! - Position consolidation
 //! - Performance analytics
 //! - Batch operations
+//!
+//! ## Access Control
+//! - **Admin**: `create_monitored_position`, `create_batch_operation`,
+//!   `rebalance_position` — gated by a broken `require_admin()` (compares the
+//!   contract's own address, not the caller). See `docs/ACCESS_CONTROL_MATRIX.md`.
+//! - **Keeper**: `monitor_positions`, `execute_batch_operation`, `acknowledge_alert` —
+//!   no auth check at all; any caller can execute another user's pending batch or
+//!   acknowledge any alert.
+//! - **User**: read-only (`get_position_analytics`, `get_user_alerts`).
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec, Map, unwrap::UnwrapOptimized};
 use crate::types::synthetic::{

--- a/src/contracts/price_feed_adapters.rs
+++ b/src/contracts/price_feed_adapters.rs
@@ -2,6 +2,13 @@
 //!
 //! Provides specialized adapters for different types of price feed sources
 //! and asset categories, with category-specific validation and processing.
+//!
+//! ## Access Control
+//! - **Admin**: `register_adapter`, `activate_adapter`, `deactivate_adapter`,
+//!   `update_adapter_settings`, `update_category_config` — gated by a broken
+//!   `require_admin()` (compares the contract's own address, not the caller). See
+//!   `docs/ACCESS_CONTROL_MATRIX.md`.
+//! - **User**: read-only (adapter/category config lookups, `validate_price`).
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec, Map, unwrap::UnwrapOptimized};
 use crate::types::asset::{

--- a/src/contracts/price_oracle.rs
+++ b/src/contracts/price_oracle.rs
@@ -11,6 +11,16 @@
 //! - Circuit breaker for extreme price movements
 //! - Governance-controlled price sources
 //! - Automatic halt on excessive volatility
+//!
+//! ## Access Control
+//! - **Admin**: `add_price_source`, `remove_price_source`, `update_source_weight`,
+//!   `set_price_update_threshold`, `reset_circuit_breaker`,
+//!   `set_circuit_breaker_enabled`, `pause`, `unpause` — gated by a broken
+//!   `require_admin()` (compares the contract's own address, not the caller). See
+//!   `docs/ACCESS_CONTROL_MATRIX.md`.
+//! - **Keeper**: `update_price` — only checks the source address is *listed*, never
+//!   authenticates it; any caller can spoof a registered source.
+//! - **User**: read-only (price/TWAP/source/alert lookups).
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec, Map, unwrap::UnwrapOptimized};
 use crate::types::stablecoin::{OraclePrice, PriceDeviationAlert, AlertSeverity};

--- a/src/contracts/soroban_token_contract.rs
+++ b/src/contracts/soroban_token_contract.rs
@@ -1,4 +1,13 @@
 //! Soroban SDK token contract implementation (issue #20)
+//!
+//! ## Access Control
+//! One of the few contracts in this codebase with fully correct enforcement — see
+//! `docs/ACCESS_CONTROL_MATRIX.md`.
+//! - **Admin**: `mint` — enforced via `admin.require_auth()` plus a stored-admin
+//!   equality check.
+//! - **User**: `transfer` — enforced via `from.require_auth()`.
+//! - Caveat: `initialize` has no re-initialization guard, so it can be called more
+//!   than once to reset admin/supply state.
 
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol};
 

--- a/src/contracts/stability_pool.rs
+++ b/src/contracts/stability_pool.rs
@@ -10,6 +10,15 @@
 //! - Reward distribution from liquidation gains
 //! - Early withdrawal penalties
 //! - Governance-controlled parameters
+//!
+//! ## Access Control
+//! - **Admin**: `update_params`, `pause`, `unpause`, `update_treasury` — gated by a
+//!   broken `require_admin()` (compares the contract's own address, not the caller).
+//!   See `docs/ACCESS_CONTROL_MATRIX.md`.
+//! - **Keeper**: `process_liquidation` — intended for the lending/vault contract, but
+//!   has no auth check at all.
+//! - **User**: `deposit`, `withdraw`, `claim_rewards` — none call `require_auth()` on
+//!   the `depositor` address; any caller can withdraw/claim on behalf of any depositor.
 
 use crate::types::stablecoin::{
     LiquidationEvent, StabilityPoolDepositEvent, StabilityPoolInfo, StabilityPoolWithdrawalEvent,

--- a/src/contracts/stablecoin.rs
+++ b/src/contracts/stablecoin.rs
@@ -11,6 +11,15 @@
 //! - Oracle integration for price feeds
 //! - Governance controls for parameter management
 //! - Emergency shutdown functionality
+//!
+//! ## Access Control
+//! - **Admin**: `add_collateral`, `pause`, `unpause`, `emergency_shutdown`,
+//!   `set_minting_fee`, `set_redemption_fee` — gated by a broken `require_admin()`
+//!   (compares the contract's own address, not the caller). See
+//!   `docs/ACCESS_CONTROL_MATRIX.md`.
+//! - **Keeper**: `liquidate` — intended for any external liquidator, no auth check.
+//! - **User**: `mint`, `redeem`, `deposit_stability_pool`, `withdraw_stability_pool` —
+//!   none of these call `require_auth()` on the acting address (`to`/`from`/`depositor`).
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec, Map, unwrap::UnwrapOptimized};
 use soroban_token_sdk::{Token, TokenInterface};

--- a/src/contracts/staking.rs
+++ b/src/contracts/staking.rs
@@ -1,6 +1,12 @@
 //! Staking Contract
 //!
 //! Implements staking with lock-up periods and different APY tiers.
+//!
+//! ## Access Control
+//! One of the few contracts in this codebase with fully correct enforcement — see
+//! `docs/ACCESS_CONTROL_MATRIX.md`.
+//! - **Admin**: `set_tier` — enforced via `admin.require_auth()`.
+//! - **User**: `stake`, `withdraw` — enforced via `user.require_auth()`.
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Map, Symbol};
 

--- a/src/contracts/synthetic_governance.rs
+++ b/src/contracts/synthetic_governance.rs
@@ -10,6 +10,18 @@
 //! - Timelock execution
 //! - Voting power delegation
 //! - Emergency controls
+//!
+//! ## Access Control
+//! - **Admin**: `create_multisig_requirement`, `pause`, `unpause`,
+//!   `update_governance_params`, `emergency_pause` — gated by a broken
+//!   `require_admin()` (compares the contract's own address, not the caller). See
+//!   `docs/ACCESS_CONTROL_MATRIX.md`.
+//! - **Governance**: `create_proposal`, `vote`, `delegate` — no `require_auth()` on
+//!   proposer/voter/delegator; voting power is mocked to a constant and the
+//!   double-vote guard (`has_voted`) always returns `false`.
+//! - **Keeper**: `execute_proposal` — permissionless by design, after the voting/
+//!   execution-delay timelock.
+//! - **User**: read-only (proposal/voting-power/params lookups).
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec, Map, unwrap::UnwrapOptimized};
 use crate::types::synthetic::{

--- a/src/contracts/synthetic_protocol.rs
+++ b/src/contracts/synthetic_protocol.rs
@@ -11,6 +11,15 @@
 //! - Fee distribution to stakers
 //! - Governance for asset listing
 //! - Comprehensive risk management
+//!
+//! ## Access Control
+//! - **Admin**: `list_asset`, `pause`, `unpause`, `update_risk_params` — gated by a
+//!   broken `require_admin()` (compares the contract's own address, not the caller).
+//!   See `docs/ACCESS_CONTROL_MATRIX.md`.
+//! - **Keeper**: `liquidate_position`, `update_oracle_price` — no auth check;
+//!   `update_oracle_price` only checks whitelist membership, not caller identity.
+//! - **User**: `mint_synthetic`, `burn_synthetic`, `stake`, `unstake` — none call
+//!   `require_auth()` on the acting `user` address.
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec, Map, unwrap::UnwrapOptimized};
 use crate::types::synthetic::{

--- a/src/contracts/token.rs
+++ b/src/contracts/token.rs
@@ -2,6 +2,14 @@
 //!
 //! Provides ERC-20-like token functionality on the Stellar blockchain
 //! using Soroban smart contracts.
+//!
+//! ## Access Control
+//! This is a plain in-memory Rust struct, not a deployed Soroban `#[contract]` — there
+//! is no `Env`/`require_auth` capability in this file at all, so `mint`, `burn`,
+//! `transfer`, `approve`, and `transfer_from` have **no access control whatsoever**;
+//! any caller can act on behalf of any address. See `docs/ACCESS_CONTROL_MATRIX.md`
+//! for the full breakdown and the deployable, correctly-authenticated alternative in
+//! `soroban_token_contract.rs`.
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec};
 use crate::types::token::{TokenInfo, TokenMetadata};

--- a/src/contracts/vault.rs
+++ b/src/contracts/vault.rs
@@ -13,6 +13,18 @@
 //! - Yield optimization algorithm
 //! - Strategy switching logic
 //! - Harvest and reinvest functions
+//!
+//! ## Access Control
+//! - **Admin**: `add_strategy`, `switch_strategy`, `optimize_strategy`,
+//!   `collect_fees`, `pause`, `unpause`, `emergency_exit`, `set_performance_fee`,
+//!   `set_treasury` — `require_admin()` only checks that an admin has been
+//!   configured, not that the caller *is* the admin (the source even flags this:
+//!   `// In production: verify env.invoker() == self.admin`). See
+//!   `docs/ACCESS_CONTROL_MATRIX.md`.
+//! - **Keeper**: `harvest` — open to any caller, rate-limited only by
+//!   `MIN_HARVEST_INTERVAL`, not by auth.
+//! - **User**: `deposit`, `withdraw` — no identity check at all, compounded by the
+//!   lack of a per-user share ledger (only a single aggregate `total_shares`).
 
 use soroban_sdk::{contract, Address, Env, Vec};
 use soroban_sdk::testutils::Address as _;


### PR DESCRIPTION
… docs

## Summary
- Adds `docs/ACCESS_CONTROL_MATRIX.md`: full Contract x Role x Action permission matrix (#257), plus per-contract `## Access Control` doc comments in `src/contracts/`.
- Adds `docs/SECURITY_AUDIT_CHECKLIST.md`: threat model, pre-audit checklist, mitigation reference, and review cadence (#256), plus `.github/SECURITY.md` vulnerability disclosure policy.
- Adds `docs/ARCHITECTURE.md`: component diagram, key sequence diagrams, protocol-wide economic model with formulas, and consolidated risk parameters (#255).
- Updates `CONTRIBUTING.md` and `README.md` to link the new docs and set expectations for keeping them current.

## Note
Building the access-control matrix surfaced real enforcement gaps (broken `require_admin` checks, missing `require_auth` on user-facing functions) across most contracts. These are recorded as known findings in the matrix/checklist appendices for follow-up — this PR is documentation only and does not change contract logic.

Closes #257, closes #256, closes #255, closes #254.

## Test plan
- [ ] Doc-only change; no `cargo test` impact expected (doc-comment additions only)
- [ ] Review rendered markdown/mermaid diagrams for correctness
ere.