### PR TITLE
feat: implement asset allowlist/blocklist, metadata, risk params, migration (#215 #216 #217 #218)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,16 @@ soroban/
 test-data/
 fixtures/
 
+# Test snapshots (auto-generated, not part of reviewed work)
+test_snapshots/
+**/*.snap
+**/*.snap.new
+
+# Test snapshots (auto-generated, not part of reviewed work)
+test_snapshots/
+**/*.snap
+**/*.snap.new
+
 # Documentation build
 /docs/build/
 /book/

--- a/src/contracts/asset_registry_protocol.rs
+++ b/src/contracts/asset_registry_protocol.rs
@@ -1,0 +1,680 @@
+//! Protocol-level Asset Registry (pure Rust, no Soroban SDK dependency)
+//!
+//! Implements a comprehensive asset registry used by all protocol contracts.
+//! This module fulfils four GitHub issues:
+//!
+//! ## Issue #215 – Allowlist / Blocklist Management
+//! - [`AssetRegistry::allowlist_asset`] / [`AssetRegistry::remove_from_allowlist`]
+//! - [`AssetRegistry::blocklist_asset`] / [`AssetRegistry::remove_from_blocklist`]
+//! - Blocklist always takes precedence over allowlist.
+//! - Events emitted for every change via [`AssetRegistry::drain_events`].
+//!
+//! ## Issue #216 – Asset Metadata Registry with Token Standards
+//! - [`AssetRegistry::register_asset`] stores [`ProtocolAssetMetadata`].
+//! - [`AssetRegistry::update_asset_metadata`] lets admin update metadata.
+//! - [`AssetRegistry::get_asset_metadata`] makes metadata queryable.
+//! - Validates token standard on registration.
+//!
+//! ## Issue #217 – Asset Risk Parameters per Collateral Type
+//! - [`AssetRegistry::set_risk_params`] stores [`AssetRiskParams`].
+//! - [`AssetRegistry::get_risk_params`] makes params queryable.
+//! - LTV ≤ liquidation threshold invariant enforced.
+//!
+//! ## Issue #218 – Asset Upgrade and Migration Path
+//! - [`AssetRegistry::initiate_migration`] starts a migration.
+//! - [`AssetRegistry::complete_migration`] verifies and finalises.
+//! - [`AssetRegistry::cancel_migration`] rolls back before completion.
+//! - Emits [`MigrationEvent`] entries for a full audit trail.
+
+use std::collections::HashMap;
+
+use crate::types::asset::{
+    AssetRiskParams, ListChangeEvent, ListChangeReason, MigrationEvent, MigrationState,
+    MigrationStatus, ProtocolAssetMetadata, RegistryListEntry, TokenStandard,
+};
+
+// ─── Registry-level errors ───────────────────────────────────────────────────
+
+/// Errors returned by [`AssetRegistry`] operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegistryError {
+    /// Caller is not an authorised admin.
+    Unauthorized,
+    /// The asset is already in the specified list.
+    AlreadyInList,
+    /// The asset is not in the specified list.
+    NotInList,
+    /// The asset metadata has already been registered.
+    AlreadyRegistered,
+    /// No metadata found for the given asset.
+    NotRegistered,
+    /// The supplied risk parameters fail the internal invariant check.
+    InvalidRiskParams,
+    /// A migration already exists for this asset and is not yet completed.
+    MigrationAlreadyActive,
+    /// No active migration found for this asset.
+    NoActiveMigration,
+    /// The migration has already been completed or cancelled.
+    MigrationNotInProgress,
+    /// Generic validation error with a message.
+    ValidationError(String),
+}
+
+impl std::fmt::Display for RegistryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RegistryError::Unauthorized => write!(f, "caller is not an admin"),
+            RegistryError::AlreadyInList => write!(f, "asset is already in this list"),
+            RegistryError::NotInList => write!(f, "asset is not in this list"),
+            RegistryError::AlreadyRegistered => write!(f, "asset metadata already registered"),
+            RegistryError::NotRegistered => write!(f, "asset not registered"),
+            RegistryError::InvalidRiskParams => write!(f, "invalid risk parameters"),
+            RegistryError::MigrationAlreadyActive => {
+                write!(f, "a migration is already active for this asset")
+            }
+            RegistryError::NoActiveMigration => {
+                write!(f, "no active migration found for this asset")
+            }
+            RegistryError::MigrationNotInProgress => {
+                write!(f, "migration is not in progress")
+            }
+            RegistryError::ValidationError(msg) => write!(f, "validation error: {}", msg),
+        }
+    }
+}
+
+// ─── Registry events (combined from all issues) ───────────────────────────────
+
+/// All observable events emitted by the registry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegistryEvent {
+    /// An allowlist/blocklist change was made (issue #215).
+    ListChange(ListChangeEvent),
+    /// Asset metadata was registered or updated (issue #216).
+    MetadataRegistered {
+        asset_id: String,
+    },
+    /// Asset metadata was updated by an admin (issue #216).
+    MetadataUpdated {
+        asset_id: String,
+        updated_by: String,
+    },
+    /// Risk parameters were set or updated (issue #217).
+    RiskParamsSet {
+        asset_id: String,
+        updated_by: String,
+    },
+    /// A migration lifecycle event occurred (issue #218).
+    Migration(MigrationEvent),
+}
+
+// ─── Main Registry struct ─────────────────────────────────────────────────────
+
+/// Protocol-level asset registry.
+///
+/// Holds authorised admin addresses plus four independent data stores:
+/// allowlist, blocklist, metadata, risk parameters, and migrations.
+#[derive(Debug, Clone)]
+pub struct AssetRegistry {
+    /// Set of admin addresses that may mutate registry state.
+    admins: Vec<String>,
+    // ── Issue #215: allow / block lists ──────────────────────────────────────
+    allowlist: HashMap<String, RegistryListEntry>,
+    blocklist: HashMap<String, RegistryListEntry>,
+    // ── Issue #216: metadata ─────────────────────────────────────────────────
+    metadata: HashMap<String, ProtocolAssetMetadata>,
+    // ── Issue #217: risk parameters ──────────────────────────────────────────
+    risk_params: HashMap<String, AssetRiskParams>,
+    // ── Issue #218: migrations ───────────────────────────────────────────────
+    migrations: HashMap<String, MigrationState>,
+    // ── Append-only event log ─────────────────────────────────────────────────
+    events: Vec<RegistryEvent>,
+}
+
+impl AssetRegistry {
+    // ─── Construction ─────────────────────────────────────────────────────────
+
+    /// Create a new, empty registry with the given admin addresses.
+    ///
+    /// At least one admin must be provided.
+    ///
+    /// # Panics
+    /// Panics if `admins` is empty.
+    pub fn new(admins: Vec<String>) -> Self {
+        assert!(!admins.is_empty(), "registry must have at least one admin");
+        Self {
+            admins,
+            allowlist: HashMap::new(),
+            blocklist: HashMap::new(),
+            metadata: HashMap::new(),
+            risk_params: HashMap::new(),
+            migrations: HashMap::new(),
+            events: Vec::new(),
+        }
+    }
+
+    /// Return a reference to the accumulated event log.
+    pub fn events(&self) -> &[RegistryEvent] {
+        &self.events
+    }
+
+    /// Drain and return all accumulated events, clearing the internal log.
+    pub fn drain_events(&mut self) -> Vec<RegistryEvent> {
+        std::mem::take(&mut self.events)
+    }
+
+    // ─── Internal helpers ─────────────────────────────────────────────────────
+
+    fn ensure_admin(&self, caller: &str) -> Result<(), RegistryError> {
+        if self.admins.iter().any(|a| a == caller) {
+            Ok(())
+        } else {
+            Err(RegistryError::Unauthorized)
+        }
+    }
+
+    fn emit(&mut self, event: RegistryEvent) {
+        self.events.push(event);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Issue #215 – Allowlist / Blocklist Management
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Add an asset to the **allowlist** (governance-controlled).
+    ///
+    /// Returns [`RegistryError::AlreadyInList`] if the asset is already allowed.
+    pub fn allowlist_asset(
+        &mut self,
+        caller: &str,
+        asset_id: &str,
+        reason: ListChangeReason,
+        now: u64,
+    ) -> Result<(), RegistryError> {
+        self.ensure_admin(caller)?;
+
+        if self.allowlist.contains_key(asset_id) {
+            return Err(RegistryError::AlreadyInList);
+        }
+
+        self.allowlist.insert(
+            asset_id.to_string(),
+            RegistryListEntry {
+                asset_id: asset_id.to_string(),
+                changed_by: caller.to_string(),
+                reason: reason.clone(),
+                recorded_at: now,
+                active: true,
+            },
+        );
+
+        self.emit(RegistryEvent::ListChange(ListChangeEvent::AllowlistAdded {
+            asset_id: asset_id.to_string(),
+            changed_by: caller.to_string(),
+            reason,
+        }));
+
+        Ok(())
+    }
+
+    /// Remove an asset from the **allowlist**.
+    ///
+    /// Returns [`RegistryError::NotInList`] if the asset is not currently allowed.
+    pub fn remove_from_allowlist(
+        &mut self,
+        caller: &str,
+        asset_id: &str,
+    ) -> Result<(), RegistryError> {
+        self.ensure_admin(caller)?;
+
+        if !self.allowlist.contains_key(asset_id) {
+            return Err(RegistryError::NotInList);
+        }
+
+        self.allowlist.remove(asset_id);
+
+        self.emit(RegistryEvent::ListChange(ListChangeEvent::AllowlistRemoved {
+            asset_id: asset_id.to_string(),
+            changed_by: caller.to_string(),
+        }));
+
+        Ok(())
+    }
+
+    /// Add an asset to the **blocklist** (governance-controlled).
+    ///
+    /// Returns [`RegistryError::AlreadyInList`] if the asset is already blocked.
+    pub fn blocklist_asset(
+        &mut self,
+        caller: &str,
+        asset_id: &str,
+        reason: ListChangeReason,
+        now: u64,
+    ) -> Result<(), RegistryError> {
+        self.ensure_admin(caller)?;
+
+        if self.blocklist.contains_key(asset_id) {
+            return Err(RegistryError::AlreadyInList);
+        }
+
+        self.blocklist.insert(
+            asset_id.to_string(),
+            RegistryListEntry {
+                asset_id: asset_id.to_string(),
+                changed_by: caller.to_string(),
+                reason: reason.clone(),
+                recorded_at: now,
+                active: true,
+            },
+        );
+
+        self.emit(RegistryEvent::ListChange(ListChangeEvent::BlocklistAdded {
+            asset_id: asset_id.to_string(),
+            changed_by: caller.to_string(),
+            reason,
+        }));
+
+        Ok(())
+    }
+
+    /// Remove an asset from the **blocklist**.
+    ///
+    /// Returns [`RegistryError::NotInList`] if the asset is not currently blocked.
+    pub fn remove_from_blocklist(
+        &mut self,
+        caller: &str,
+        asset_id: &str,
+    ) -> Result<(), RegistryError> {
+        self.ensure_admin(caller)?;
+
+        if !self.blocklist.contains_key(asset_id) {
+            return Err(RegistryError::NotInList);
+        }
+
+        self.blocklist.remove(asset_id);
+
+        self.emit(RegistryEvent::ListChange(ListChangeEvent::BlocklistRemoved {
+            asset_id: asset_id.to_string(),
+            changed_by: caller.to_string(),
+        }));
+
+        Ok(())
+    }
+
+    /// Returns `true` when the asset is allowed for protocol use.
+    ///
+    /// **Blocklist takes precedence**: an asset that is both allowlisted and
+    /// blocklisted is treated as *not* allowed.
+    pub fn is_allowed(&self, asset_id: &str) -> bool {
+        if self.blocklist.contains_key(asset_id) {
+            return false;
+        }
+        self.allowlist
+            .get(asset_id)
+            .map(|e| e.active)
+            .unwrap_or(false)
+    }
+
+    /// Returns `true` when the asset is on the blocklist.
+    pub fn is_blocked(&self, asset_id: &str) -> bool {
+        self.blocklist.contains_key(asset_id)
+    }
+
+    /// Returns the full allowlist entries.
+    pub fn allowlist(&self) -> Vec<&RegistryListEntry> {
+        self.allowlist.values().collect()
+    }
+
+    /// Returns the full blocklist entries.
+    pub fn blocklist(&self) -> Vec<&RegistryListEntry> {
+        self.blocklist.values().collect()
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Issue #216 – Asset Metadata Registry with Token Standards
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Register metadata for a new asset.
+    ///
+    /// Validates the token standard.  Returns [`RegistryError::AlreadyRegistered`]
+    /// if metadata for this `asset_id` already exists.
+    pub fn register_asset(
+        &mut self,
+        caller: &str,
+        metadata: ProtocolAssetMetadata,
+        now: u64,
+    ) -> Result<(), RegistryError> {
+        self.ensure_admin(caller)?;
+
+        if self.metadata.contains_key(&metadata.asset_id) {
+            return Err(RegistryError::AlreadyRegistered);
+        }
+
+        // Standard validation: native assets must not carry a contract address.
+        if metadata.standard == TokenStandard::StellarNative
+            && !metadata.contract_address.is_empty()
+        {
+            return Err(RegistryError::ValidationError(
+                "StellarNative assets must not have a contract address".to_string(),
+            ));
+        }
+
+        // SEP-41 and wrapped assets must carry a contract address.
+        if (metadata.standard == TokenStandard::Sep41
+            || metadata.standard == TokenStandard::Wrapped)
+            && metadata.contract_address.is_empty()
+        {
+            return Err(RegistryError::ValidationError(format!(
+                "{} assets must have a contract address",
+                metadata.standard
+            )));
+        }
+
+        let asset_id = metadata.asset_id.clone();
+        let mut entry = metadata;
+        entry.registered_at = now;
+        entry.last_updated_at = now;
+        entry.active = true;
+
+        self.metadata.insert(asset_id.clone(), entry);
+
+        self.emit(RegistryEvent::MetadataRegistered {
+            asset_id,
+        });
+
+        Ok(())
+    }
+
+    /// Update metadata for an already-registered asset (admin only).
+    ///
+    /// The `asset_id` field in the new metadata must match the existing record.
+    pub fn update_asset_metadata(
+        &mut self,
+        caller: &str,
+        new_metadata: ProtocolAssetMetadata,
+        now: u64,
+    ) -> Result<(), RegistryError> {
+        self.ensure_admin(caller)?;
+
+        let entry = self
+            .metadata
+            .get_mut(&new_metadata.asset_id)
+            .ok_or(RegistryError::NotRegistered)?;
+
+        let mut updated = new_metadata;
+        updated.registered_at = entry.registered_at; // preserve original timestamp
+        updated.last_updated_at = now;
+
+        let asset_id = updated.asset_id.clone();
+        *entry = updated;
+
+        self.emit(RegistryEvent::MetadataUpdated {
+            asset_id,
+            updated_by: caller.to_string(),
+        });
+
+        Ok(())
+    }
+
+    /// Retrieve metadata for an asset.
+    pub fn get_asset_metadata(&self, asset_id: &str) -> Option<&ProtocolAssetMetadata> {
+        self.metadata.get(asset_id)
+    }
+
+    /// Returns `true` if metadata exists for `asset_id`.
+    pub fn is_registered(&self, asset_id: &str) -> bool {
+        self.metadata.contains_key(asset_id)
+    }
+
+    /// Returns all registered asset metadata entries.
+    pub fn all_assets(&self) -> Vec<&ProtocolAssetMetadata> {
+        self.metadata.values().collect()
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Issue #217 – Asset Risk Parameters per Collateral Type
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Set (or update) risk parameters for a collateral asset.
+    ///
+    /// Validates `ltv_bps ≤ liquidation_threshold_bps ≤ 10_000`.
+    /// The asset must already be registered in the metadata store.
+    pub fn set_risk_params(
+        &mut self,
+        caller: &str,
+        params: AssetRiskParams,
+        now: u64,
+    ) -> Result<(), RegistryError> {
+        self.ensure_admin(caller)?;
+
+        if !self.metadata.contains_key(&params.asset_id) {
+            return Err(RegistryError::NotRegistered);
+        }
+
+        if !params.is_valid() {
+            return Err(RegistryError::InvalidRiskParams);
+        }
+
+        let asset_id = params.asset_id.clone();
+        let mut p = params;
+        p.last_updated_at = now;
+
+        self.risk_params.insert(asset_id.clone(), p);
+
+        self.emit(RegistryEvent::RiskParamsSet {
+            asset_id,
+            updated_by: caller.to_string(),
+        });
+
+        Ok(())
+    }
+
+    /// Retrieve risk parameters for a collateral asset.
+    pub fn get_risk_params(&self, asset_id: &str) -> Option<&AssetRiskParams> {
+        self.risk_params.get(asset_id)
+    }
+
+    /// Returns all risk parameter records.
+    pub fn all_risk_params(&self) -> Vec<&AssetRiskParams> {
+        self.risk_params.values().collect()
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Issue #218 – Asset Upgrade and Migration Path
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Initiate a migration from `old_contract` to `new_contract`.
+    ///
+    /// Takes snapshots of `balances` and `allowances` for on-chain verification.
+    /// The asset must be registered.  Only one active migration per asset is
+    /// allowed at a time.
+    ///
+    /// # Arguments
+    /// * `caller` – initiating admin.
+    /// * `asset_id` – canonical identifier of the asset being migrated.
+    /// * `old_contract` – address of the contract being replaced.
+    /// * `new_contract` – address of the replacement contract.
+    /// * `balances` – snapshot of all holder balances from the old contract.
+    /// * `allowances` – snapshot of all approvals from the old contract.
+    /// * `total_supply` – total supply on the old contract at snapshot time.
+    /// * `now` – current ledger timestamp.
+    #[allow(clippy::too_many_arguments)]
+    pub fn initiate_migration(
+        &mut self,
+        caller: &str,
+        asset_id: &str,
+        old_contract: &str,
+        new_contract: &str,
+        balances: HashMap<String, u64>,
+        allowances: HashMap<String, HashMap<String, u64>>,
+        total_supply: u64,
+        now: u64,
+    ) -> Result<(), RegistryError> {
+        self.ensure_admin(caller)?;
+
+        if !self.metadata.contains_key(asset_id) {
+            return Err(RegistryError::NotRegistered);
+        }
+
+        // Disallow a second concurrent migration.
+        if let Some(existing) = self.migrations.get(asset_id) {
+            if existing.status == MigrationStatus::Pending
+                || existing.status == MigrationStatus::InProgress
+            {
+                return Err(RegistryError::MigrationAlreadyActive);
+            }
+        }
+
+        // Basic validation: verify balance sum equals total_supply.
+        let balance_sum: u64 = balances.values().sum();
+        if balance_sum != total_supply {
+            return Err(RegistryError::ValidationError(format!(
+                "balance snapshot sum ({}) does not equal total_supply ({})",
+                balance_sum, total_supply
+            )));
+        }
+
+        self.migrations.insert(
+            asset_id.to_string(),
+            MigrationState {
+                asset_id: asset_id.to_string(),
+                old_contract: old_contract.to_string(),
+                new_contract: new_contract.to_string(),
+                balance_snapshot: balances,
+                allowance_snapshot: allowances,
+                total_supply_snapshot: total_supply,
+                status: MigrationStatus::InProgress,
+                initiated_by: caller.to_string(),
+                initiated_at: now,
+                completed_at: 0,
+                old_contract_paused: false,
+            },
+        );
+
+        self.emit(RegistryEvent::Migration(MigrationEvent::Initiated {
+            asset_id: asset_id.to_string(),
+            old_contract: old_contract.to_string(),
+            new_contract: new_contract.to_string(),
+            initiated_by: caller.to_string(),
+        }));
+
+        Ok(())
+    }
+
+    /// Complete a migration.
+    ///
+    /// Verifies that the on-chain balances on the new contract (`new_balances`)
+    /// match the snapshot taken at initiation.  If verification passes:
+    /// 1. Allowances are considered migrated.
+    /// 2. Old contract is marked as paused.
+    /// 3. Migration status is set to [`MigrationStatus::Completed`].
+    ///
+    /// # Arguments
+    /// * `caller` – completing admin.
+    /// * `asset_id` – asset under migration.
+    /// * `new_balances` – on-chain balances read from the new contract.
+    /// * `now` – current ledger timestamp.
+    pub fn complete_migration(
+        &mut self,
+        caller: &str,
+        asset_id: &str,
+        new_balances: &HashMap<String, u64>,
+        now: u64,
+    ) -> Result<(), RegistryError> {
+        self.ensure_admin(caller)?;
+
+        let state = self
+            .migrations
+            .get_mut(asset_id)
+            .ok_or(RegistryError::NoActiveMigration)?;
+
+        if state.status != MigrationStatus::InProgress {
+            return Err(RegistryError::MigrationNotInProgress);
+        }
+
+        // On-chain balance verification: every snapshotted holder must exist in
+        // new_balances with the identical amount.
+        for (address, expected_amount) in &state.balance_snapshot {
+            let actual = new_balances.get(address).copied().unwrap_or(0);
+            if actual != *expected_amount {
+                return Err(RegistryError::ValidationError(format!(
+                    "balance mismatch for {}: expected {}, got {}",
+                    address, expected_amount, actual
+                )));
+            }
+        }
+
+        let accounts_migrated = state.balance_snapshot.len() as u64;
+        let total_supply = state.total_supply_snapshot;
+        let allowances_migrated: u64 = state
+            .allowance_snapshot
+            .values()
+            .map(|m| m.len() as u64)
+            .sum();
+        let old_contract = state.old_contract.clone();
+        let new_contract = state.new_contract.clone();
+
+        // Mark old contract as paused.
+        state.old_contract_paused = true;
+        state.status = MigrationStatus::Completed;
+        state.completed_at = now;
+
+        self.emit(RegistryEvent::Migration(MigrationEvent::BalancesMigrated {
+            asset_id: asset_id.to_string(),
+            accounts_migrated,
+            total_supply,
+        }));
+
+        self.emit(RegistryEvent::Migration(MigrationEvent::AllowancesMigrated {
+            asset_id: asset_id.to_string(),
+            allowances_migrated,
+        }));
+
+        self.emit(RegistryEvent::Migration(MigrationEvent::OldContractPaused {
+            asset_id: asset_id.to_string(),
+            old_contract: old_contract.clone(),
+        }));
+
+        self.emit(RegistryEvent::Migration(MigrationEvent::Completed {
+            asset_id: asset_id.to_string(),
+            old_contract,
+            new_contract,
+        }));
+
+        Ok(())
+    }
+
+    /// Cancel an in-progress or pending migration.
+    ///
+    /// The old contract is left running; no state is transferred.
+    pub fn cancel_migration(
+        &mut self,
+        caller: &str,
+        asset_id: &str,
+    ) -> Result<(), RegistryError> {
+        self.ensure_admin(caller)?;
+
+        let state = self
+            .migrations
+            .get_mut(asset_id)
+            .ok_or(RegistryError::NoActiveMigration)?;
+
+        if state.status == MigrationStatus::Completed {
+            return Err(RegistryError::MigrationNotInProgress);
+        }
+
+        state.status = MigrationStatus::Cancelled;
+
+        self.emit(RegistryEvent::Migration(MigrationEvent::Cancelled {
+            asset_id: asset_id.to_string(),
+            cancelled_by: caller.to_string(),
+        }));
+
+        Ok(())
+    }
+
+    /// Retrieve the current migration state for an asset.
+    pub fn get_migration_state(&self, asset_id: &str) -> Option<&MigrationState> {
+        self.migrations.get(asset_id)
+    }
+}

--- a/src/contracts/lending.rs
+++ b/src/contracts/lending.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 
 use soroban_sdk::{contract, contractimpl, contracttype, contracterror, Address, Env, Symbol, log};
 
+use crate::contracts::asset_registry_protocol::AssetRegistry;
 use crate::contracts::oracle::PriceOracleSim;
 use crate::types::{
     AccountPosition, AdminAction, AdminProposal, AdminProposalStatus, FlashLoanReceipt,
@@ -55,6 +56,9 @@ pub struct LendingProtocol {
     paused: bool,
     /// Append-only event log.  Drain with `drain_events()`.
     events: Vec<ProtocolEvent>,
+    /// Asset allowlist/blocklist registry (issue #215).
+    /// When set, deposit and borrow will check registry approval.
+    asset_registry: Option<AssetRegistry>,
 }
 
 impl LendingProtocol {
@@ -76,6 +80,7 @@ impl LendingProtocol {
             close_factor_bps: 5_000,
             paused: false,
             events: Vec::new(),
+            asset_registry: None,
         }
     }
 
@@ -96,6 +101,37 @@ impl LendingProtocol {
     /// Returns `true` when the protocol is currently paused.
     pub fn is_paused(&self) -> bool {
         self.paused
+    }
+
+    // ─── Asset Registry Integration (issue #215) ─────────────────────────────
+
+    /// Attach an [`AssetRegistry`] to this protocol instance.
+    ///
+    /// Once attached, [`deposit`] and [`borrow`] will reject assets that are
+    /// either not on the allowlist or are on the blocklist.
+    pub fn attach_asset_registry(&mut self, registry: AssetRegistry) {
+        self.asset_registry = Some(registry);
+    }
+
+    /// Returns a reference to the attached [`AssetRegistry`], if any.
+    pub fn asset_registry(&self) -> Option<&AssetRegistry> {
+        self.asset_registry.as_ref()
+    }
+
+    /// Returns a mutable reference to the attached [`AssetRegistry`], if any.
+    pub fn asset_registry_mut(&mut self) -> Option<&mut AssetRegistry> {
+        self.asset_registry.as_mut()
+    }
+
+    /// Returns `Err(ProtocolError::AssetNotAllowed)` when a registry is attached
+    /// and the asset is either not allowlisted or is blocklisted.
+    fn ensure_asset_allowed(&self, asset: &str) -> Result<(), ProtocolError> {
+        if let Some(registry) = &self.asset_registry {
+            if !registry.is_allowed(asset) {
+                return Err(ProtocolError::AssetNotAllowed(asset.to_string()));
+            }
+        }
+        Ok(())
     }
 
     /// Pause all user-facing protocol operations (admin only).
@@ -499,6 +535,8 @@ impl LendingProtocol {
     ) -> Result<i128, ProtocolError> {
         self.ensure_not_paused()?;
         self.ensure_positive(amount)?;
+        // Issue #215: reject assets not approved by the registry.
+        self.ensure_asset_allowed(asset)?;
         self.accrue_interest(asset, now)?;
         let config = self
             .reserve_configs
@@ -674,6 +712,8 @@ impl LendingProtocol {
     ) -> Result<i128, ProtocolError> {
         self.ensure_not_paused()?;
         self.ensure_positive(amount)?;
+        // Issue #215: reject assets not approved by the registry.
+        self.ensure_asset_allowed(asset)?;
         self.accrue_interest(asset, now)?;
         let config = self
             .reserve_configs

--- a/src/contracts/mod.rs
+++ b/src/contracts/mod.rs
@@ -10,6 +10,7 @@
 //! liquidity_pool, multi_asset_oracle, oracle_manager, position_manager,
 //! price_feed_adapters, price_oracle, stability_pool, stablecoin, staking,
 //! synthetic_governance, synthetic_protocol, token, vault.
+pub mod asset_registry_protocol;
 pub mod lending;
 pub mod oracle;
 pub mod oracle_manager;

--- a/src/contracts/token.rs
+++ b/src/contracts/token.rs
@@ -40,6 +40,8 @@ pub struct TokenContract {
     recovery_requests: HashMap<String, (u64, u64)>,
     /// Recovery delay in seconds
     recovery_delay: u64,
+    /// Whether the contract is paused (set after migration – issue #218).
+    paused: bool,
 }
 
 impl TokenContract {
@@ -56,6 +58,105 @@ impl TokenContract {
             admin: None,
             recovery_requests: HashMap::new(),
             recovery_delay: 86400,
+            paused: false,
+        }
+    }
+
+    // ─── Issue #218 – Migration Interface ─────────────────────────────────────
+
+    /// Returns `true` if this contract has been paused (e.g. after migration).
+    pub fn is_paused(&self) -> bool {
+        self.paused
+    }
+
+    /// Pause the contract.  Only the admin may call this.
+    ///
+    /// In a migration scenario the protocol calls this after all state has been
+    /// transferred to the new contract.
+    pub fn pause(&mut self, caller: &str) -> Result<(), String> {
+        self.ensure_admin(caller)?;
+        self.paused = true;
+        println!("[Event] ContractPaused {{ contract: {:?} }}", self.address);
+        Ok(())
+    }
+
+    /// Unpause the contract (admin only).
+    pub fn unpause(&mut self, caller: &str) -> Result<(), String> {
+        self.ensure_admin(caller)?;
+        self.paused = false;
+        println!("[Event] ContractUnpaused {{ contract: {:?} }}", self.address);
+        Ok(())
+    }
+
+    /// Export a snapshot of all balances for migration verification.
+    ///
+    /// Returns a `HashMap<String, u64>` of address → balance together with the
+    /// current total supply so the caller can verify sum(balances) == total_supply.
+    pub fn export_balance_snapshot(&self) -> (HashMap<String, u64>, u64) {
+        (self.balances.clone(), self.total_supply)
+    }
+
+    /// Export a snapshot of all allowances for migration.
+    pub fn export_allowance_snapshot(&self) -> HashMap<String, HashMap<String, u64>> {
+        self.allowances.clone()
+    }
+
+    /// Import balances from a migration snapshot into a *new* contract instance.
+    ///
+    /// This is called on the **new** contract to replay the old contract's state.
+    /// Validates that the sum of imported balances equals `expected_total_supply`.
+    pub fn import_migration_state(
+        &mut self,
+        balances: HashMap<String, u64>,
+        allowances: HashMap<String, HashMap<String, u64>>,
+        expected_total_supply: u64,
+    ) -> Result<(), String> {
+        if self.paused {
+            return Err("contract is paused".to_string());
+        }
+
+        // Verify balance integrity.
+        let sum: u64 = balances.values().sum();
+        if sum != expected_total_supply {
+            return Err(format!(
+                "balance snapshot sum ({}) does not match expected total supply ({})",
+                sum, expected_total_supply
+            ));
+        }
+
+        self.balances = balances;
+        self.allowances = allowances;
+        self.total_supply = expected_total_supply;
+
+        println!(
+            "[Event] MigrationStateImported {{ total_supply: {}, accounts: {} }}",
+            self.total_supply,
+            self.balances.len()
+        );
+
+        Ok(())
+    }
+
+    // ─── Admin helper ─────────────────────────────────────────────────────────
+
+    /// Set the admin address (can only be done once, or must be called before any admin ops).
+    pub fn set_admin(&mut self, admin: String) {
+        self.admin = Some(admin);
+    }
+
+    fn ensure_admin(&self, caller: &str) -> Result<(), String> {
+        match &self.admin {
+            Some(admin) if admin == caller => Ok(()),
+            Some(_) => Err("caller is not the admin".to_string()),
+            None => Err("no admin configured".to_string()),
+        }
+    }
+
+    fn ensure_not_paused(&self) -> Result<(), String> {
+        if self.paused {
+            Err("contract is paused".to_string())
+        } else {
+            Ok(())
         }
     }
 
@@ -78,6 +179,7 @@ impl TokenContract {
 
     /// Mint new tokens
     pub fn mint(&mut self, to: Address, amount: u64) -> Result<(), String> {
+        self.ensure_not_paused()?;
         if amount == 0 {
             return Err("Amount must be greater than 0".to_string());
         }
@@ -120,6 +222,7 @@ impl TokenContract {
     /// Fixes issue #15: implements full transfer logic including balance check,
     /// deducting from sender, crediting receiver, and emitting a Transfer event.
     pub fn transfer(&mut self, from: Address, to: Address, amount: u64) -> Result<(), String> {
+        self.ensure_not_paused()?;
         if amount == 0 {
             return Err("Amount must be greater than 0".to_string());
         }

--- a/src/types/asset.rs
+++ b/src/types/asset.rs
@@ -2,8 +2,252 @@
 //!
 //! This module provides type definitions for a wide range of Stellar assets,
 //! including native assets, custom tokens, stablecoins, wrapped assets, and more.
+//!
+//! ## Issue #215 – Allowlist / Blocklist
+//! [`RegistryListEntry`] and [`ListChangeEvent`] support allow/block management.
+//!
+//! ## Issue #216 – Asset Metadata Registry
+//! [`ProtocolAssetMetadata`] stores name, symbol, decimals, token standard and
+//! contract address.  [`TokenStandard`] enumerates the supported standards.
+//!
+//! ## Issue #217 – Risk Parameters
+//! [`AssetRiskParams`] holds LTV, liquidation threshold, liquidation bonus and
+//! oracle source per collateral asset.
+//!
+//! ## Issue #218 – Asset Migration
+//! [`MigrationState`], [`MigrationStatus`] and [`MigrationEvent`] define the
+//! upgrade/migration path for token contracts.
 
 use soroban_sdk::{Address, Symbol, Map, Vec};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// ─── Issue #215 – Allowlist / Blocklist ──────────────────────────────────────
+
+/// Describes why an asset was added to (or removed from) a registry list.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ListChangeReason {
+    /// Added through normal governance approval.
+    GovernanceApproval,
+    /// Removed after governance vote.
+    GovernanceRemoval,
+    /// Emergency block by an admin (e.g. exploit risk).
+    EmergencyBlock,
+    /// Administrative action without a full governance vote.
+    AdminAction,
+    /// Free-form reason provided at registration time.
+    Custom(String),
+}
+
+/// A single entry in either the allowlist or the blocklist.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegistryListEntry {
+    /// Canonical asset identifier (contract address string or ticker).
+    pub asset_id: String,
+    /// The admin / governance address that made the change.
+    pub changed_by: String,
+    /// Human-readable reason.
+    pub reason: ListChangeReason,
+    /// Ledger / unix timestamp at which the entry was recorded.
+    pub recorded_at: u64,
+    /// Whether the entry is currently active (can be soft-deleted).
+    pub active: bool,
+}
+
+/// Events emitted when the allowlist or blocklist changes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ListChangeEvent {
+    /// Asset was added to the allowlist.
+    AllowlistAdded {
+        asset_id: String,
+        changed_by: String,
+        reason: ListChangeReason,
+    },
+    /// Asset was removed from the allowlist.
+    AllowlistRemoved {
+        asset_id: String,
+        changed_by: String,
+    },
+    /// Asset was added to the blocklist.
+    BlocklistAdded {
+        asset_id: String,
+        changed_by: String,
+        reason: ListChangeReason,
+    },
+    /// Asset was removed from the blocklist.
+    BlocklistRemoved {
+        asset_id: String,
+        changed_by: String,
+    },
+}
+
+// ─── Issue #216 – Asset Metadata & Token Standards ───────────────────────────
+
+/// Recognised token standards on Stellar / Soroban.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TokenStandard {
+    /// Stellar native asset (XLM).
+    StellarNative,
+    /// SEP-41 fungible token interface.
+    Sep41,
+    /// Classic Stellar asset (SEP-0011 / TOML-described).
+    ClassicStellarAsset,
+    /// Wrapped asset bridged from another chain.
+    Wrapped,
+    /// Custom / unknown standard.
+    Custom(String),
+}
+
+impl std::fmt::Display for TokenStandard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TokenStandard::StellarNative => write!(f, "StellarNative"),
+            TokenStandard::Sep41 => write!(f, "SEP-41"),
+            TokenStandard::ClassicStellarAsset => write!(f, "ClassicStellarAsset"),
+            TokenStandard::Wrapped => write!(f, "Wrapped"),
+            TokenStandard::Custom(s) => write!(f, "Custom({})", s),
+        }
+    }
+}
+
+/// Full metadata for a protocol-registered asset (issue #216).
+///
+/// Queryable by any contract via [`AssetRegistry::get_asset_metadata`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProtocolAssetMetadata {
+    /// Canonical asset identifier (contract address string or ticker).
+    pub asset_id: String,
+    /// Human-readable asset name (e.g. "USD Coin").
+    pub name: String,
+    /// Ticker symbol (e.g. "USDC").
+    pub symbol: String,
+    /// Number of decimal places (e.g. 7 for Stellar-native, 6 for USDC).
+    pub decimals: u8,
+    /// On-chain contract address (empty string for native XLM).
+    pub contract_address: String,
+    /// Token standard this asset conforms to.
+    pub standard: TokenStandard,
+    /// Whether the metadata record is currently valid / active.
+    pub active: bool,
+    /// Ledger timestamp when this metadata was first registered.
+    pub registered_at: u64,
+    /// Ledger timestamp of the most recent admin metadata update.
+    pub last_updated_at: u64,
+}
+
+// ─── Issue #217 – Risk Parameters ────────────────────────────────────────────
+
+/// Risk parameters for an asset used as collateral (issue #217).
+///
+/// All ratio fields are expressed in *basis points* (1 bps = 0.01 %).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AssetRiskParams {
+    /// Canonical asset identifier.
+    pub asset_id: String,
+    /// Loan-to-value ratio in bps (e.g. 7500 = 75 %).
+    /// The maximum a borrower can draw against this collateral.
+    pub ltv_bps: u32,
+    /// Liquidation threshold in bps (e.g. 8000 = 80 %).
+    /// Below this health-factor the position becomes liquidatable.
+    pub liquidation_threshold_bps: u32,
+    /// Liquidation bonus in bps (e.g. 500 = 5 %).
+    /// Extra collateral reward paid to the liquidator.
+    pub liquidation_bonus_bps: u32,
+    /// Identifier of the oracle / price-source assigned to this asset.
+    pub oracle_source: String,
+    /// Ledger timestamp when these parameters were last set.
+    pub last_updated_at: u64,
+}
+
+impl AssetRiskParams {
+    /// Basic invariant: LTV ≤ liquidation threshold.
+    pub fn is_valid(&self) -> bool {
+        self.ltv_bps <= self.liquidation_threshold_bps
+            && self.liquidation_threshold_bps <= 10_000
+            && self.liquidation_bonus_bps <= 5_000
+    }
+}
+
+// ─── Issue #218 – Migration / Upgrade Path ────────────────────────────────────
+
+/// Current phase of a token-contract migration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MigrationStatus {
+    /// Migration has been requested but not yet started.
+    Pending,
+    /// Balances are being migrated.
+    InProgress,
+    /// All state has been transferred; old contract is paused.
+    Completed,
+    /// Migration was cancelled before completion.
+    Cancelled,
+}
+
+/// Tracks the full state of a token-contract upgrade/migration (issue #218).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MigrationState {
+    /// Asset being migrated.
+    pub asset_id: String,
+    /// Address of the old (source) contract.
+    pub old_contract: String,
+    /// Address of the new (destination) contract.
+    pub new_contract: String,
+    /// Snapshot of all balances at migration initiation: address → amount.
+    pub balance_snapshot: HashMap<String, u64>,
+    /// Snapshot of all allowances: owner → (spender → amount).
+    pub allowance_snapshot: HashMap<String, HashMap<String, u64>>,
+    /// Total supply at the time the migration was initiated.
+    pub total_supply_snapshot: u64,
+    /// Current migration phase.
+    pub status: MigrationStatus,
+    /// Address that initiated the migration.
+    pub initiated_by: String,
+    /// Ledger timestamp when migration was initiated.
+    pub initiated_at: u64,
+    /// Ledger timestamp when migration completed (0 if not yet done).
+    pub completed_at: u64,
+    /// Whether the old contract has been paused post-migration.
+    pub old_contract_paused: bool,
+}
+
+/// Audit-trail events emitted during a migration (issue #218).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MigrationEvent {
+    /// Migration was initiated.
+    Initiated {
+        asset_id: String,
+        old_contract: String,
+        new_contract: String,
+        initiated_by: String,
+    },
+    /// Balances were successfully transferred to the new contract.
+    BalancesMigrated {
+        asset_id: String,
+        accounts_migrated: u64,
+        total_supply: u64,
+    },
+    /// Allowances were successfully transferred to the new contract.
+    AllowancesMigrated {
+        asset_id: String,
+        allowances_migrated: u64,
+    },
+    /// The old contract was paused to prevent further operations.
+    OldContractPaused {
+        asset_id: String,
+        old_contract: String,
+    },
+    /// Migration completed successfully.
+    Completed {
+        asset_id: String,
+        old_contract: String,
+        new_contract: String,
+    },
+    /// Migration was cancelled (old contract remains active).
+    Cancelled {
+        asset_id: String,
+        cancelled_by: String,
+    },
+}
 
 /// Stellar asset identifier - can be native XLM or a custom token
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/types/lending.rs
+++ b/src/types/lending.rs
@@ -327,6 +327,9 @@ pub enum ProtocolError {
     InsufficientApprovals,
     #[error("caller already approved this proposal")]
     AlreadyApproved,
+    /// Emitted when an asset is not on the allowlist (or is blocklisted).
+    #[error("asset {0} is not allowed by the asset registry")]
+    AssetNotAllowed(String),
 }
 
 impl InterestRateModel {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -3,6 +3,7 @@
 //! NOTE: `asset`, `pool`, `stablecoin`, `synthetic`, `token`, and `vault` are
 //! temporarily excluded — see `contracts/mod.rs` for why.
 
+pub mod asset;
 pub mod lending;
 
 pub use lending::*;

--- a/tests/asset_registry_tests.rs
+++ b/tests/asset_registry_tests.rs
@@ -1,0 +1,745 @@
+//! Tests for issues #215, #216, #217, #218 – asset registry.
+
+use stellar_defi_toolkit::contracts::asset_registry_protocol::{AssetRegistry, RegistryError};
+use stellar_defi_toolkit::types::asset::{
+    AssetRiskParams, ListChangeReason, MigrationStatus, ProtocolAssetMetadata, TokenStandard,
+};
+use std::collections::HashMap;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn registry() -> AssetRegistry {
+    AssetRegistry::new(vec!["admin".to_string()])
+}
+
+fn usdc_meta(now: u64) -> ProtocolAssetMetadata {
+    ProtocolAssetMetadata {
+        asset_id: "USDC".to_string(),
+        name: "USD Coin".to_string(),
+        symbol: "USDC".to_string(),
+        decimals: 6,
+        contract_address: "CABC123".to_string(),
+        standard: TokenStandard::Sep41,
+        active: true,
+        registered_at: now,
+        last_updated_at: now,
+    }
+}
+
+fn xlm_meta(now: u64) -> ProtocolAssetMetadata {
+    ProtocolAssetMetadata {
+        asset_id: "XLM".to_string(),
+        name: "Stellar Lumens".to_string(),
+        symbol: "XLM".to_string(),
+        decimals: 7,
+        contract_address: "".to_string(),
+        standard: TokenStandard::StellarNative,
+        active: true,
+        registered_at: now,
+        last_updated_at: now,
+    }
+}
+
+fn usdc_risk() -> AssetRiskParams {
+    AssetRiskParams {
+        asset_id: "USDC".to_string(),
+        ltv_bps: 8000,
+        liquidation_threshold_bps: 8500,
+        liquidation_bonus_bps: 500,
+        oracle_source: "pyth".to_string(),
+        last_updated_at: 0,
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #215 – Allowlist / Blocklist
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn allowlist_asset_succeeds_for_admin() {
+    let mut reg = registry();
+    reg.allowlist_asset("admin", "USDC", ListChangeReason::GovernanceApproval, 1)
+        .unwrap();
+    assert!(reg.is_allowed("USDC"));
+}
+
+#[test]
+fn allowlist_rejects_non_admin() {
+    let mut reg = registry();
+    let err = reg
+        .allowlist_asset("eve", "USDC", ListChangeReason::GovernanceApproval, 1)
+        .unwrap_err();
+    assert_eq!(err, RegistryError::Unauthorized);
+}
+
+#[test]
+fn allowlist_duplicate_returns_error() {
+    let mut reg = registry();
+    reg.allowlist_asset("admin", "USDC", ListChangeReason::GovernanceApproval, 1)
+        .unwrap();
+    let err = reg
+        .allowlist_asset("admin", "USDC", ListChangeReason::GovernanceApproval, 2)
+        .unwrap_err();
+    assert_eq!(err, RegistryError::AlreadyInList);
+}
+
+#[test]
+fn remove_from_allowlist_works() {
+    let mut reg = registry();
+    reg.allowlist_asset("admin", "USDC", ListChangeReason::GovernanceApproval, 1)
+        .unwrap();
+    reg.remove_from_allowlist("admin", "USDC").unwrap();
+    assert!(!reg.is_allowed("USDC"));
+}
+
+#[test]
+fn remove_from_allowlist_not_present_returns_error() {
+    let mut reg = registry();
+    let err = reg.remove_from_allowlist("admin", "USDC").unwrap_err();
+    assert_eq!(err, RegistryError::NotInList);
+}
+
+#[test]
+fn blocklist_asset_succeeds() {
+    let mut reg = registry();
+    reg.blocklist_asset("admin", "BAD", ListChangeReason::EmergencyBlock, 1)
+        .unwrap();
+    assert!(reg.is_blocked("BAD"));
+}
+
+#[test]
+fn blocklist_takes_precedence_over_allowlist() {
+    let mut reg = registry();
+    reg.allowlist_asset("admin", "USDC", ListChangeReason::GovernanceApproval, 1)
+        .unwrap();
+    reg.blocklist_asset("admin", "USDC", ListChangeReason::EmergencyBlock, 2)
+        .unwrap();
+    // Even though USDC is allowlisted, the blocklist wins.
+    assert!(!reg.is_allowed("USDC"));
+    assert!(reg.is_blocked("USDC"));
+}
+
+#[test]
+fn remove_from_blocklist_works() {
+    let mut reg = registry();
+    reg.blocklist_asset("admin", "BAD", ListChangeReason::EmergencyBlock, 1)
+        .unwrap();
+    reg.remove_from_blocklist("admin", "BAD").unwrap();
+    assert!(!reg.is_blocked("BAD"));
+}
+
+#[test]
+fn blocklist_rejects_non_admin() {
+    let mut reg = registry();
+    let err = reg
+        .blocklist_asset("eve", "BAD", ListChangeReason::EmergencyBlock, 1)
+        .unwrap_err();
+    assert_eq!(err, RegistryError::Unauthorized);
+}
+
+#[test]
+fn events_emitted_for_allowlist_changes() {
+    use stellar_defi_toolkit::types::asset::ListChangeEvent;
+    use stellar_defi_toolkit::contracts::asset_registry_protocol::RegistryEvent;
+
+    let mut reg = registry();
+    reg.allowlist_asset("admin", "USDC", ListChangeReason::GovernanceApproval, 1)
+        .unwrap();
+    reg.remove_from_allowlist("admin", "USDC").unwrap();
+
+    let events = reg.drain_events();
+    assert_eq!(events.len(), 2);
+    assert!(matches!(
+        &events[0],
+        RegistryEvent::ListChange(ListChangeEvent::AllowlistAdded { asset_id, .. })
+        if asset_id == "USDC"
+    ));
+    assert!(matches!(
+        &events[1],
+        RegistryEvent::ListChange(ListChangeEvent::AllowlistRemoved { asset_id, .. })
+        if asset_id == "USDC"
+    ));
+}
+
+#[test]
+fn events_emitted_for_blocklist_changes() {
+    use stellar_defi_toolkit::types::asset::ListChangeEvent;
+    use stellar_defi_toolkit::contracts::asset_registry_protocol::RegistryEvent;
+
+    let mut reg = registry();
+    reg.blocklist_asset("admin", "BAD", ListChangeReason::EmergencyBlock, 1)
+        .unwrap();
+    reg.remove_from_blocklist("admin", "BAD").unwrap();
+
+    let events = reg.drain_events();
+    assert_eq!(events.len(), 2);
+    assert!(matches!(
+        &events[0],
+        RegistryEvent::ListChange(ListChangeEvent::BlocklistAdded { asset_id, .. })
+        if asset_id == "BAD"
+    ));
+    assert!(matches!(
+        &events[1],
+        RegistryEvent::ListChange(ListChangeEvent::BlocklistRemoved { asset_id, .. })
+        if asset_id == "BAD"
+    ));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #216 – Asset Metadata Registry with Token Standards
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn register_asset_metadata_succeeds() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    let meta = reg.get_asset_metadata("USDC").unwrap();
+    assert_eq!(meta.symbol, "USDC");
+    assert_eq!(meta.decimals, 6);
+    assert_eq!(meta.standard, TokenStandard::Sep41);
+    assert_eq!(meta.contract_address, "CABC123");
+}
+
+#[test]
+fn register_asset_sets_active_and_timestamps() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(42), 42).unwrap();
+    let meta = reg.get_asset_metadata("USDC").unwrap();
+    assert!(meta.active);
+    assert_eq!(meta.registered_at, 42);
+    assert_eq!(meta.last_updated_at, 42);
+}
+
+#[test]
+fn register_asset_duplicate_returns_error() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    let err = reg.register_asset("admin", usdc_meta(2), 2).unwrap_err();
+    assert_eq!(err, RegistryError::AlreadyRegistered);
+}
+
+#[test]
+fn register_asset_rejects_non_admin() {
+    let mut reg = registry();
+    let err = reg
+        .register_asset("eve", usdc_meta(1), 1)
+        .unwrap_err();
+    assert_eq!(err, RegistryError::Unauthorized);
+}
+
+#[test]
+fn register_native_asset_with_contract_address_fails_validation() {
+    let mut reg = registry();
+    let mut bad_meta = xlm_meta(1);
+    bad_meta.contract_address = "CSHOULD_NOT_EXIST".to_string();
+    let err = reg.register_asset("admin", bad_meta, 1).unwrap_err();
+    assert!(matches!(err, RegistryError::ValidationError(_)));
+}
+
+#[test]
+fn register_sep41_without_contract_address_fails_validation() {
+    let mut reg = registry();
+    let mut bad_meta = usdc_meta(1);
+    bad_meta.contract_address = "".to_string();
+    let err = reg.register_asset("admin", bad_meta, 1).unwrap_err();
+    assert!(matches!(err, RegistryError::ValidationError(_)));
+}
+
+#[test]
+fn register_native_asset_without_contract_address_succeeds() {
+    let mut reg = registry();
+    reg.register_asset("admin", xlm_meta(1), 1).unwrap();
+    let meta = reg.get_asset_metadata("XLM").unwrap();
+    assert_eq!(meta.standard, TokenStandard::StellarNative);
+    assert_eq!(meta.contract_address, "");
+}
+
+#[test]
+fn update_asset_metadata_succeeds() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+
+    let mut updated = usdc_meta(1);
+    updated.name = "USD Circle Coin".to_string();
+    reg.update_asset_metadata("admin", updated, 100).unwrap();
+
+    let meta = reg.get_asset_metadata("USDC").unwrap();
+    assert_eq!(meta.name, "USD Circle Coin");
+    assert_eq!(meta.last_updated_at, 100);
+    assert_eq!(meta.registered_at, 1); // original preserved
+}
+
+#[test]
+fn update_metadata_for_unregistered_asset_returns_error() {
+    let mut reg = registry();
+    let err = reg
+        .update_asset_metadata("admin", usdc_meta(1), 1)
+        .unwrap_err();
+    assert_eq!(err, RegistryError::NotRegistered);
+}
+
+#[test]
+fn all_assets_returns_all_registered() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    reg.register_asset("admin", xlm_meta(1), 1).unwrap();
+    assert_eq!(reg.all_assets().len(), 2);
+}
+
+#[test]
+fn is_registered_returns_correct_values() {
+    let mut reg = registry();
+    assert!(!reg.is_registered("USDC"));
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    assert!(reg.is_registered("USDC"));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #217 – Asset Risk Parameters per Collateral Type
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn set_risk_params_succeeds() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    reg.set_risk_params("admin", usdc_risk(), 1).unwrap();
+    let params = reg.get_risk_params("USDC").unwrap();
+    assert_eq!(params.ltv_bps, 8000);
+    assert_eq!(params.liquidation_threshold_bps, 8500);
+    assert_eq!(params.liquidation_bonus_bps, 500);
+    assert_eq!(params.oracle_source, "pyth");
+}
+
+#[test]
+fn set_risk_params_records_timestamp() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    reg.set_risk_params("admin", usdc_risk(), 99).unwrap();
+    assert_eq!(reg.get_risk_params("USDC").unwrap().last_updated_at, 99);
+}
+
+#[test]
+fn set_risk_params_rejects_non_admin() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    let err = reg
+        .set_risk_params("eve", usdc_risk(), 1)
+        .unwrap_err();
+    assert_eq!(err, RegistryError::Unauthorized);
+}
+
+#[test]
+fn set_risk_params_requires_asset_registered() {
+    let mut reg = registry();
+    let err = reg.set_risk_params("admin", usdc_risk(), 1).unwrap_err();
+    assert_eq!(err, RegistryError::NotRegistered);
+}
+
+#[test]
+fn set_risk_params_rejects_ltv_above_threshold() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    let bad = AssetRiskParams {
+        asset_id: "USDC".to_string(),
+        ltv_bps: 9000,
+        liquidation_threshold_bps: 8500, // LTV > threshold — invalid
+        liquidation_bonus_bps: 500,
+        oracle_source: "pyth".to_string(),
+        last_updated_at: 0,
+    };
+    let err = reg.set_risk_params("admin", bad, 1).unwrap_err();
+    assert_eq!(err, RegistryError::InvalidRiskParams);
+}
+
+#[test]
+fn set_risk_params_rejects_threshold_above_10000() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    let bad = AssetRiskParams {
+        asset_id: "USDC".to_string(),
+        ltv_bps: 8000,
+        liquidation_threshold_bps: 10_001,
+        liquidation_bonus_bps: 500,
+        oracle_source: "pyth".to_string(),
+        last_updated_at: 0,
+    };
+    let err = reg.set_risk_params("admin", bad, 1).unwrap_err();
+    assert_eq!(err, RegistryError::InvalidRiskParams);
+}
+
+#[test]
+fn risk_params_queryable_returns_none_when_not_set() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    assert!(reg.get_risk_params("USDC").is_none());
+}
+
+#[test]
+fn risk_params_can_be_updated() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    reg.set_risk_params("admin", usdc_risk(), 1).unwrap();
+
+    let updated = AssetRiskParams {
+        asset_id: "USDC".to_string(),
+        ltv_bps: 7500,
+        liquidation_threshold_bps: 8000,
+        liquidation_bonus_bps: 300,
+        oracle_source: "band".to_string(),
+        last_updated_at: 0,
+    };
+    reg.set_risk_params("admin", updated, 50).unwrap();
+    let params = reg.get_risk_params("USDC").unwrap();
+    assert_eq!(params.ltv_bps, 7500);
+    assert_eq!(params.oracle_source, "band");
+}
+
+#[test]
+fn all_risk_params_returns_all_entries() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    reg.register_asset("admin", xlm_meta(1), 1).unwrap();
+    reg.set_risk_params("admin", usdc_risk(), 1).unwrap();
+    let xlm_risk = AssetRiskParams {
+        asset_id: "XLM".to_string(),
+        ltv_bps: 7000,
+        liquidation_threshold_bps: 7500,
+        liquidation_bonus_bps: 1000,
+        oracle_source: "pyth".to_string(),
+        last_updated_at: 0,
+    };
+    reg.set_risk_params("admin", xlm_risk, 1).unwrap();
+    assert_eq!(reg.all_risk_params().len(), 2);
+}
+
+#[test]
+fn risk_params_event_emitted() {
+    use stellar_defi_toolkit::contracts::asset_registry_protocol::RegistryEvent;
+
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    reg.drain_events(); // clear registration event
+    reg.set_risk_params("admin", usdc_risk(), 1).unwrap();
+
+    let events = reg.drain_events();
+    assert_eq!(events.len(), 1);
+    assert!(matches!(
+        &events[0],
+        RegistryEvent::RiskParamsSet { asset_id, .. } if asset_id == "USDC"
+    ));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #218 – Asset Upgrade and Migration Path
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn sample_balances() -> HashMap<String, u64> {
+    let mut b = HashMap::new();
+    b.insert("alice".to_string(), 600);
+    b.insert("bob".to_string(), 400);
+    b
+}
+
+fn sample_allowances() -> HashMap<String, HashMap<String, u64>> {
+    let mut inner = HashMap::new();
+    inner.insert("spender1".to_string(), 100u64);
+    let mut a = HashMap::new();
+    a.insert("alice".to_string(), inner);
+    a
+}
+
+#[test]
+fn initiate_migration_succeeds() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    reg.initiate_migration(
+        "admin", "USDC", "OLD_CONTRACT", "NEW_CONTRACT",
+        sample_balances(), sample_allowances(), 1000, 10,
+    ).unwrap();
+    let state = reg.get_migration_state("USDC").unwrap();
+    assert_eq!(state.status, MigrationStatus::InProgress);
+    assert_eq!(state.old_contract, "OLD_CONTRACT");
+    assert_eq!(state.new_contract, "NEW_CONTRACT");
+    assert_eq!(state.total_supply_snapshot, 1000);
+}
+
+#[test]
+fn initiate_migration_rejects_non_admin() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    let err = reg.initiate_migration(
+        "eve", "USDC", "OLD", "NEW",
+        sample_balances(), sample_allowances(), 1000, 10,
+    ).unwrap_err();
+    assert_eq!(err, RegistryError::Unauthorized);
+}
+
+#[test]
+fn initiate_migration_requires_registered_asset() {
+    let mut reg = registry();
+    let err = reg.initiate_migration(
+        "admin", "USDC", "OLD", "NEW",
+        sample_balances(), sample_allowances(), 1000, 10,
+    ).unwrap_err();
+    assert_eq!(err, RegistryError::NotRegistered);
+}
+
+#[test]
+fn initiate_migration_rejects_balance_sum_mismatch() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    // balances sum to 1000 but we pass 999 as total_supply
+    let err = reg.initiate_migration(
+        "admin", "USDC", "OLD", "NEW",
+        sample_balances(), sample_allowances(), 999, 10,
+    ).unwrap_err();
+    assert!(matches!(err, RegistryError::ValidationError(_)));
+}
+
+#[test]
+fn initiate_migration_rejects_duplicate_active_migration() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    reg.initiate_migration(
+        "admin", "USDC", "OLD", "NEW",
+        sample_balances(), sample_allowances(), 1000, 10,
+    ).unwrap();
+    let err = reg.initiate_migration(
+        "admin", "USDC", "OLD2", "NEW2",
+        sample_balances(), sample_allowances(), 1000, 20,
+    ).unwrap_err();
+    assert_eq!(err, RegistryError::MigrationAlreadyActive);
+}
+
+#[test]
+fn complete_migration_verifies_balances_on_new_contract() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    reg.initiate_migration(
+        "admin", "USDC", "OLD", "NEW",
+        sample_balances(), sample_allowances(), 1000, 10,
+    ).unwrap();
+
+    // Provide matching new-contract balances
+    reg.complete_migration("admin", "USDC", &sample_balances(), 20).unwrap();
+
+    let state = reg.get_migration_state("USDC").unwrap();
+    assert_eq!(state.status, MigrationStatus::Completed);
+    assert!(state.old_contract_paused);
+    assert_eq!(state.completed_at, 20);
+}
+
+#[test]
+fn complete_migration_fails_on_balance_mismatch() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    reg.initiate_migration(
+        "admin", "USDC", "OLD", "NEW",
+        sample_balances(), sample_allowances(), 1000, 10,
+    ).unwrap();
+
+    // Incorrect balances on new contract
+    let mut wrong = sample_balances();
+    wrong.insert("alice".to_string(), 500); // should be 600
+    let err = reg.complete_migration("admin", "USDC", &wrong, 20).unwrap_err();
+    assert!(matches!(err, RegistryError::ValidationError(_)));
+}
+
+#[test]
+fn complete_migration_emits_audit_events() {
+    use stellar_defi_toolkit::contracts::asset_registry_protocol::RegistryEvent;
+    use stellar_defi_toolkit::types::asset::MigrationEvent;
+
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    reg.initiate_migration(
+        "admin", "USDC", "OLD", "NEW",
+        sample_balances(), sample_allowances(), 1000, 10,
+    ).unwrap();
+    reg.drain_events(); // clear prior events
+
+    reg.complete_migration("admin", "USDC", &sample_balances(), 20).unwrap();
+
+    let events = reg.drain_events();
+    // Should emit: BalancesMigrated, AllowancesMigrated, OldContractPaused, Completed
+    assert_eq!(events.len(), 4);
+    assert!(matches!(
+        &events[0],
+        RegistryEvent::Migration(MigrationEvent::BalancesMigrated { asset_id, .. })
+        if asset_id == "USDC"
+    ));
+    assert!(matches!(
+        &events[3],
+        RegistryEvent::Migration(MigrationEvent::Completed { asset_id, .. })
+        if asset_id == "USDC"
+    ));
+}
+
+#[test]
+fn cancel_migration_works() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    reg.initiate_migration(
+        "admin", "USDC", "OLD", "NEW",
+        sample_balances(), sample_allowances(), 1000, 10,
+    ).unwrap();
+    reg.cancel_migration("admin", "USDC").unwrap();
+    let state = reg.get_migration_state("USDC").unwrap();
+    assert_eq!(state.status, MigrationStatus::Cancelled);
+}
+
+#[test]
+fn cancel_migration_emits_event() {
+    use stellar_defi_toolkit::contracts::asset_registry_protocol::RegistryEvent;
+    use stellar_defi_toolkit::types::asset::MigrationEvent;
+
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    reg.initiate_migration(
+        "admin", "USDC", "OLD", "NEW",
+        sample_balances(), sample_allowances(), 1000, 10,
+    ).unwrap();
+    reg.drain_events();
+    reg.cancel_migration("admin", "USDC").unwrap();
+
+    let events = reg.drain_events();
+    assert_eq!(events.len(), 1);
+    assert!(matches!(
+        &events[0],
+        RegistryEvent::Migration(MigrationEvent::Cancelled { asset_id, .. })
+        if asset_id == "USDC"
+    ));
+}
+
+#[test]
+fn cancel_completed_migration_returns_error() {
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    reg.initiate_migration(
+        "admin", "USDC", "OLD", "NEW",
+        sample_balances(), sample_allowances(), 1000, 10,
+    ).unwrap();
+    reg.complete_migration("admin", "USDC", &sample_balances(), 20).unwrap();
+    let err = reg.cancel_migration("admin", "USDC").unwrap_err();
+    assert_eq!(err, RegistryError::MigrationNotInProgress);
+}
+
+#[test]
+fn migration_initiation_event_emitted() {
+    use stellar_defi_toolkit::contracts::asset_registry_protocol::RegistryEvent;
+    use stellar_defi_toolkit::types::asset::MigrationEvent;
+
+    let mut reg = registry();
+    reg.register_asset("admin", usdc_meta(1), 1).unwrap();
+    reg.drain_events();
+    reg.initiate_migration(
+        "admin", "USDC", "OLD", "NEW",
+        sample_balances(), sample_allowances(), 1000, 10,
+    ).unwrap();
+
+    let events = reg.drain_events();
+    assert_eq!(events.len(), 1);
+    assert!(matches!(
+        &events[0],
+        RegistryEvent::Migration(MigrationEvent::Initiated { asset_id, .. })
+        if asset_id == "USDC"
+    ));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #215 – Lending protocol registry integration
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn lending_deposit_blocked_when_asset_not_allowed() {
+    use stellar_defi_toolkit::{InterestRateModel, LendingProtocol, ProtocolError, ReserveConfig};
+
+    let mut protocol = LendingProtocol::new(
+        vec!["admin".to_string()], 1, "treasury", InterestRateModel::default(),
+    );
+    protocol.register_asset("admin", ReserveConfig {
+        asset: "USDC".to_string(),
+        decimals: 6,
+        collateral_factor_bps: 8000,
+        liquidation_threshold_bps: 8500,
+        liquidation_bonus_bps: 500,
+        reserve_factor_bps: 1000,
+        flash_loan_fee_bps: 9,
+        borrow_enabled: true,
+        deposit_enabled: true,
+        flash_loan_enabled: true,
+        supply_cap: 0,
+        borrow_cap: 0,
+        interest_rate_model: None,
+    }, 0).unwrap();
+
+    // Attach registry with USDC NOT allowlisted
+    let reg = AssetRegistry::new(vec!["admin".to_string()]);
+    protocol.attach_asset_registry(reg);
+
+    let err = protocol.deposit("alice", "USDC", 1_000_000, 0).unwrap_err();
+    assert!(matches!(err, ProtocolError::AssetNotAllowed(_)));
+}
+
+#[test]
+fn lending_deposit_succeeds_when_asset_allowed() {
+    use stellar_defi_toolkit::{InterestRateModel, LendingProtocol, ReserveConfig};
+
+    let mut protocol = LendingProtocol::new(
+        vec!["admin".to_string()], 1, "treasury", InterestRateModel::default(),
+    );
+    protocol.register_asset("admin", ReserveConfig {
+        asset: "USDC".to_string(),
+        decimals: 6,
+        collateral_factor_bps: 8000,
+        liquidation_threshold_bps: 8500,
+        liquidation_bonus_bps: 500,
+        reserve_factor_bps: 1000,
+        flash_loan_fee_bps: 9,
+        borrow_enabled: true,
+        deposit_enabled: true,
+        flash_loan_enabled: true,
+        supply_cap: 0,
+        borrow_cap: 0,
+        interest_rate_model: None,
+    }, 0).unwrap();
+
+    let mut reg = AssetRegistry::new(vec!["admin".to_string()]);
+    reg.allowlist_asset("admin", "USDC", ListChangeReason::GovernanceApproval, 1).unwrap();
+    protocol.attach_asset_registry(reg);
+
+    let shares = protocol.deposit("alice", "USDC", 1_000_000, 0).unwrap();
+    assert_eq!(shares, 1_000_000);
+}
+
+#[test]
+fn lending_deposit_blocked_when_asset_blocklisted() {
+    use stellar_defi_toolkit::{InterestRateModel, LendingProtocol, ProtocolError, ReserveConfig};
+
+    let mut protocol = LendingProtocol::new(
+        vec!["admin".to_string()], 1, "treasury", InterestRateModel::default(),
+    );
+    protocol.register_asset("admin", ReserveConfig {
+        asset: "USDC".to_string(),
+        decimals: 6,
+        collateral_factor_bps: 8000,
+        liquidation_threshold_bps: 8500,
+        liquidation_bonus_bps: 500,
+        reserve_factor_bps: 1000,
+        flash_loan_fee_bps: 9,
+        borrow_enabled: true,
+        deposit_enabled: true,
+        flash_loan_enabled: true,
+        supply_cap: 0,
+        borrow_cap: 0,
+        interest_rate_model: None,
+    }, 0).unwrap();
+
+    let mut reg = AssetRegistry::new(vec!["admin".to_string()]);
+    reg.allowlist_asset("admin", "USDC", ListChangeReason::GovernanceApproval, 1).unwrap();
+    reg.blocklist_asset("admin", "USDC", ListChangeReason::EmergencyBlock, 2).unwrap();
+    protocol.attach_asset_registry(reg);
+
+    let err = protocol.deposit("alice", "USDC", 1_000_000, 0).unwrap_err();
+    assert!(matches!(err, ProtocolError::AssetNotAllowed(_)));
+}


### PR DESCRIPTION
Closes #216

---

Closes #215

---

Closes #217

---

Closes #218

---

## Summary

Implements four related asset registry issues in a single cohesive PR.

---

### #215 – Asset allowlist/blocklist management
- New `AssetRegistry` struct with `allowlist_asset`, `remove_from_allowlist`, `blocklist_asset`, `remove_from_blocklist`
- Blocklist always takes precedence over allowlist (`is_allowed()` returns `false` when blocklisted even if also allowlisted)
- Governance-controlled: all mutations require an admin caller
- Events emitted for every change via `RegistryEvent::ListChange`
- `LendingProtocol::attach_asset_registry()` wires the registry in; `deposit()` and `borrow()` both call `ensure_asset_allowed()`
- New `ProtocolError::AssetNotAllowed` variant

### #216 – Asset metadata registry with token standards
- `ProtocolAssetMetadata` struct: name, symbol, decimals, standard, contract_address, timestamps
- `TokenStandard` enum: `StellarNative`, `Sep41`, `ClassicStellarAsset`, `Wrapped`, `Custom`
- Standard validation on registration (native assets must not carry a contract address; SEP-41/Wrapped must)
- Admin can update metadata; `registered_at` is preserved on update
- Queryable via `get_asset_metadata()` / `all_assets()`

### #217 – Asset risk parameters per collateral type
- `AssetRiskParams` struct: `ltv_bps`, `liquidation_threshold_bps`, `liquidation_bonus_bps`, `oracle_source`
- Invariant enforced: LTV ≤ liquidation threshold ≤ 10,000; liquidation bonus ≤ 5,000
- Asset must be registered in metadata store before risk params can be set
- Queryable via `get_risk_params()` / `all_risk_params()`
- Events emitted on set/update

### #218 – Asset upgrade and migration path
- `MigrationState`, `MigrationStatus`, `MigrationEvent` types for full audit trail
- `initiate_migration()` snapshots balances + allowances, validates sum = total_supply
- `complete_migration()` verifies new-contract balances match snapshot before finalising
- Old contract marked paused after successful migration
- `cancel_migration()` available before completion
- `TokenContract` gains: `paused` field, `pause()`/`unpause()`, `export_balance_snapshot()`, `export_allowance_snapshot()`, `import_migration_state()`
- User-facing ops (`mint`, `transfer`) reject calls when contract is paused

## Files changed
| File | Change |
|------|--------|
| `src/contracts/asset_registry_protocol.rs` | **new** – pure-Rust AssetRegistry |
| `src/types/asset.rs` | Added new types for #215-#218 |
| `src/types/lending.rs` | Added `AssetNotAllowed` error variant |
| `src/contracts/lending.rs` | Registry integration (attach + checks) |
| `src/contracts/token.rs` | Migration interface (#218) |
| `src/contracts/mod.rs` | Expose `asset_registry_protocol` module |
| `src/types/mod.rs` | Expose `asset` types module |
| `tests/asset_registry_tests.rs` | **new** – 40+ tests covering all acceptance criteria |
| `.gitignore` | Exclude `test_snapshots/`, `*.snap` |

## Testing
40+ tests in `tests/asset_registry_tests.rs` covering every acceptance criterion across all four issues including edge cases (blocklist precedence, balance mismatch, duplicate migration, invalid risk params, etc.).

All build errors visible locally are pre-existing on `main` and unrelated to this PR (broken Soroban SDK imports in `oracle_manager`, `vault`, etc. that were already excluded from compilation).